### PR TITLE
middleware: add `Logger` and `Recovery`

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -6,6 +6,7 @@ package flamego
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,4 +37,104 @@ func TestContext_Next(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, "foobarfoo2", buf.String())
+}
+
+func TestContext_RemoteAddr(t *testing.T) {
+	f := NewWithLogger(&bytes.Buffer{})
+	f.Get("/", func(c Context) string {
+		return c.RemoteAddr()
+	})
+
+	tests := []struct {
+		name           string
+		newRequest     func() *http.Request
+		wantRemoteAddr string
+	}{
+		{
+			name: "from request field",
+			newRequest: func() *http.Request {
+				req, err := http.NewRequest("GET", "/", nil)
+				assert.Nil(t, err)
+
+				req.RemoteAddr = "127.0.0.1:2830"
+				return req
+			},
+			wantRemoteAddr: "127.0.0.1",
+		},
+		{
+			name: "from X-Forwarded-For",
+			newRequest: func() *http.Request {
+				req, err := http.NewRequest("GET", "/", nil)
+				assert.Nil(t, err)
+
+				req.RemoteAddr = "127.0.0.1:2830"
+				req.Header.Set("X-Forwarded-For", "192.168.0.1")
+				return req
+			},
+			wantRemoteAddr: "192.168.0.1",
+		},
+		{
+			name: "from X-Real-IP",
+			newRequest: func() *http.Request {
+				req, err := http.NewRequest("GET", "/", nil)
+				assert.Nil(t, err)
+
+				req.RemoteAddr = "127.0.0.1:2830"
+				req.Header.Set("X-Forwarded-For", "192.168.0.1")
+				req.Header.Set("X-Real-IP", "10.0.0.1")
+				return req
+			},
+			wantRemoteAddr: "10.0.0.1",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req := test.newRequest()
+
+			f.ServeHTTP(resp, req)
+
+			assert.Equal(t, test.wantRemoteAddr, resp.Body.String())
+		})
+	}
+}
+
+func TestContext_Params(t *testing.T) {
+	f := NewWithLogger(&bytes.Buffer{})
+	tests := []struct {
+		route    string
+		url      string
+		handler  Handler
+		wantBody string
+	}{
+		{
+			route: "/params/{string}/{int}",
+			url:   "/params/hello/123",
+			handler: func(c Context) string {
+				return fmt.Sprintf("%s %s", c.Params("string"), c.Params("int"))
+			},
+			wantBody: "hello 123",
+		},
+		{
+			route: "/params-int/{string}/{int}",
+			url:   "/params-int/hello/123",
+			handler: func(c Context) string {
+				return fmt.Sprintf("%d %d", c.ParamsInt("string"), c.ParamsInt("int"))
+			},
+			wantBody: "0 123",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.route, func(t *testing.T) {
+			f.Get(test.route, test.handler)
+
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", test.url, nil)
+			assert.Nil(t, err)
+
+			f.ServeHTTP(resp, req)
+
+			assert.Equal(t, test.wantBody, resp.Body.String())
+		})
+	}
 }

--- a/flame.go
+++ b/flame.go
@@ -60,6 +60,14 @@ func New() *Flame {
 	return NewWithLogger(os.Stdout)
 }
 
+// Classic creates and returns a classic Flame instance with default middleware:
+// flamego.Logger, flamego.Recovery and flamego.Static.
+func Classic() *Flame {
+	f := New()
+	f.Use(Recovery())
+	return f
+}
+
 func (f *Flame) createContext(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) Context {
 	// Allocate a new slice to avoid mutating the original "handlers" and that could
 	// potentially cause data race.

--- a/flame.go
+++ b/flame.go
@@ -61,9 +61,10 @@ func New() *Flame {
 }
 
 // Classic creates and returns a classic Flame instance with default middleware:
-// flamego.Logger, flamego.Recovery and flamego.Static.
+// flamego.Logger, flamego.Recovery and TODO(unknwon): flamego.Static.
 func Classic() *Flame {
 	f := New()
+	f.Use(Logger())
 	f.Use(Recovery())
 	return f
 }

--- a/flame_test.go
+++ b/flame_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestClassic(t *testing.T) {
+	_ = Classic() // For the sake of code coverage
+}
+
 // Make sure Run doesn't blow up
 func TestFlame_Run(t *testing.T) {
 	_ = os.Setenv("FLAMEGO_ADDR", "0.0.0.0:4001")

--- a/flame_test.go
+++ b/flame_test.go
@@ -158,6 +158,7 @@ func TestFlame_NoRace(t *testing.T) {
 }
 
 func TestEnv(t *testing.T) {
+	defer SetEnv(EnvTypeDev)
 	envs := []EnvType{
 		EnvTypeDev,
 		EnvTypeProd,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/alecthomas/participle/v2 v2.0.0-alpha5
+	github.com/fatih/color v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,12 @@ github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1p
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -13,6 +19,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,96 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+// loggerInvoker is an inject.FastInvoker implementation of
+// `func(ctx Context, log *log.Logger)`.
+type loggerInvoker func(ctx Context, log *log.Logger)
+
+func (invoke loggerInvoker) Invoke(params []interface{}) ([]reflect.Value, error) {
+	invoke(params[0].(Context), params[1].(*log.Logger))
+	return nil, nil
+}
+
+// LoggerOptions contains options for the flamego.Logger middleware.
+type LoggerOptions struct {
+	// LogTimeFormat specifies the time format for the logger. The default format is
+	// "2006-01-02 15:04:05".
+	LogTimeFormat string
+}
+
+// Logger returns a middleware handler that logs the request as it goes in and
+// the response as it goes out.
+func Logger(opts ...LoggerOptions) Handler {
+	var opt LoggerOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	parseLoggerOptions := func(opts LoggerOptions) LoggerOptions {
+		if opts.LogTimeFormat == "" {
+			opts.LogTimeFormat = "2006-01-02 15:04:05"
+		}
+		return opts
+	}
+
+	opt = parseLoggerOptions(opt)
+
+	colors := map[color.Attribute]*color.Color{
+		color.FgGreen:   color.New(color.FgGreen),
+		color.FgHiWhite: color.New(color.FgHiWhite),
+		color.FgYellow:  color.New(color.FgYellow),
+		color.FgRed:     color.New(color.FgRed, color.Underline),
+		color.FgHiRed:   color.New(color.FgHiRed, color.Underline, color.Bold),
+		color.FgBlue:    color.New(color.FgBlue),
+	}
+
+	return loggerInvoker(func(ctx Context, log *log.Logger) {
+		started := time.Now()
+
+		log.Printf("%s: Started %s %s for %s",
+			time.Now().Format(opt.LogTimeFormat),
+			ctx.Request().Method,
+			ctx.Request().RequestURI,
+			ctx.RemoteAddr(),
+		)
+
+		w := ctx.ResponseWriter().(ResponseWriter)
+		ctx.Next()
+
+		content := fmt.Sprintf("%s: Completed %s %s %v %s in %v",
+			time.Now().Format(opt.LogTimeFormat),
+			ctx.Request().Method,
+			ctx.Request().RequestURI,
+			w.Status(),
+			http.StatusText(w.Status()),
+			time.Since(started),
+		)
+		switch w.Status() {
+		case http.StatusOK, http.StatusCreated, http.StatusAccepted:
+			content = colors[color.FgGreen].Sprintf("%s", content)
+		case http.StatusMovedPermanently, http.StatusFound:
+			content = colors[color.FgHiWhite].Sprintf("%s", content)
+		case http.StatusNotModified:
+			content = colors[color.FgYellow].Sprintf("%s", content)
+		case http.StatusUnauthorized, http.StatusForbidden:
+			content = colors[color.FgRed].Sprintf("%s", content)
+		case http.StatusNotFound:
+			content = colors[color.FgBlue].Sprintf("%s", content)
+		case http.StatusInternalServerError:
+			content = colors[color.FgHiRed].Sprintf("%s", content)
+		}
+		log.Println(content)
+	})
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/flamego/flamego/internal/inject"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger(t *testing.T) {
+	t.Run("fast invoker", func(t *testing.T) {
+		assert.True(t, inject.IsFastInvoker(Logger()))
+	})
+
+	f := NewWithLogger(&bytes.Buffer{})
+	f.Get("/{code}", func(c Context) (int, string) {
+		code := c.ParamsInt("code")
+		return code, http.StatusText(code)
+	})
+	codes := []int{
+		http.StatusOK, http.StatusCreated, http.StatusAccepted,
+		http.StatusMovedPermanently, http.StatusFound,
+		http.StatusNotModified,
+		http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+	for _, code := range codes {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", fmt.Sprintf("/%d", code), nil)
+			assert.Nil(t, err)
+
+			f.ServeHTTP(resp, req)
+
+			assert.Equal(t, code, resp.Code)
+		})
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -22,6 +22,7 @@ func TestLogger(t *testing.T) {
 	})
 
 	f := NewWithLogger(&bytes.Buffer{})
+	f.Use(Logger())
 	f.Get("/{code}", func(c Context) (int, string) {
 		code := c.ParamsInt("code")
 		return code, http.StatusText(code)

--- a/mock.go
+++ b/mock.go
@@ -12,17 +12,20 @@ import (
 var _ Context = (*mockContext)(nil)
 
 type mockContext struct {
+	*context // Only used to avoid rewriting helper methods based on mock values.
+
 	inject.Injector
 	responseWriter ResponseWriter
 	request        *Request
 
 	params route.Params
 
-	urlPath_   urlPather
-	written_   func() bool
-	next_      func()
-	setAction_ func(Handler)
-	run_       func()
+	urlPath_    urlPather
+	written_    func() bool
+	next_       func()
+	setAction_  func(Handler)
+	run_        func()
+	remoteAddr_ func() string
 }
 
 func newMockContext() *mockContext {
@@ -57,4 +60,12 @@ func (c *mockContext) setAction(h Handler) {
 
 func (c *mockContext) run() {
 	c.run_()
+}
+
+func (c *mockContext) RemoteAddr() string {
+	return c.remoteAddr_()
+}
+
+func (c *mockContext) Params(name string) string {
+	return c.params[name]
 }

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,151 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"runtime"
+
+	"github.com/flamego/flamego/internal/inject"
+)
+
+// Recovery returns a middleware handler that recovers from any panics and
+// writes a 500 status code to the response if there was one. While in
+// development mode (EnvTypeDev), Recovery will also output the panic as HTML.
+func Recovery() Handler {
+	const html = `<html>
+<head><title>PANIC: %[1]s</title>
+<meta charset="utf-8" />
+<style type="text/css">
+html, body {
+	font-family: "Roboto", sans-serif;
+	color: #333333;
+	background-color: #ea5343;
+	margin: 0px;
+}
+h1 {
+	color: #d04526;
+	background-color: #ffffff;
+	padding: 20px;
+	border-bottom: 1px dashed #2b3848;
+}
+pre {
+	margin: 20px;
+	padding: 20px;
+	border: 2px solid #2b3848;
+	background-color: #ffffff;
+	white-space: pre-wrap;       /* css-3 */
+	white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+	white-space: -pre-wrap;      /* Opera 4-6 */
+	white-space: -o-pre-wrap;    /* Opera 7 */
+	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+</style>
+</head><body>
+<h1>PANIC</h1>
+<pre style="font-weight: bold;">%[1]s</pre>
+<pre>%[2]s</pre>
+</body>
+</html>`
+
+	var (
+		dunno     = []byte("???")
+		centerDot = []byte("·")
+		dot       = []byte(".")
+		slash     = []byte("/")
+	)
+
+	// source returns a space-trimmed slice of the n'th line.
+	source := func(lines [][]byte, n int) []byte {
+		n-- // In a stack trace, lines are 1-indexed but our array is 0-indexed
+		if n < 0 || n >= len(lines) {
+			return dunno
+		}
+		return bytes.TrimSpace(lines[n])
+	}
+
+	// function returns, if possible, the name of the function containing the PC.
+	function := func(pc uintptr) []byte {
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			return dunno
+		}
+		name := []byte(fn.Name())
+		// The name includes the path name to the package, which is unnecessary since
+		// the file name is already included. Plus, it has center dots. That is, we see:
+		//	runtime/debug.*T·ptrmethod
+		// and want:
+		//	*T.ptrmethod
+		// Also the package path might contains dot (e.g. code.google.com/...), so first
+		// eliminate the path prefix.
+		if lastSlash := bytes.LastIndex(name, slash); lastSlash >= 0 {
+			name = name[lastSlash+1:]
+		}
+		if period := bytes.Index(name, dot); period >= 0 {
+			name = name[period+1:]
+		}
+		name = bytes.Replace(name, centerDot, dot, -1)
+		return name
+	}
+
+	// stack returns a nicely formated stack frame, skipping skip frames
+	stack := func(skip int) []byte {
+		buf := new(bytes.Buffer)
+		// As we loop, we open files and read them. These variables record the currently
+		// loaded file.
+		var lines [][]byte
+		var lastFile string
+		for i := skip; ; i++ { // Skip the expected number of frames
+			pc, file, line, ok := runtime.Caller(i)
+			if !ok {
+				break
+			}
+			// Print this much at least.  If we can't find the source, it won't show.
+			_, _ = fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
+			if file != lastFile {
+				data, err := ioutil.ReadFile(file)
+				if err != nil {
+					continue
+				}
+				lines = bytes.Split(data, []byte{'\n'})
+				lastFile = file
+			}
+			_, _ = fmt.Fprintf(buf, "\t%s: %s\n", function(pc), source(lines, line))
+		}
+		return buf.Bytes()
+	}
+
+	return func(c Context, log *log.Logger) {
+		defer func() {
+			if err := recover(); err != nil {
+				stack := stack(3)
+				log.Printf("PANIC: %s\n%s", err, stack)
+
+				// Lookup the current ResponseWriter
+				val := c.Value(inject.InterfaceOf((*http.ResponseWriter)(nil)))
+				w := val.Interface().(http.ResponseWriter)
+
+				// Respond with panic message only in development mode
+				var body []byte
+				if Env() == EnvTypeDev {
+					w.Header().Set("Content-Type", "text/html")
+					body = []byte(fmt.Sprintf(html, err, stack))
+				} else {
+					w.Header().Set("Content-Type", "text/plain")
+					body = []byte(http.StatusText(http.StatusInternalServerError))
+				}
+
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(body)
+			}
+		}()
+
+		c.Next()
+	}
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecovery(t *testing.T) {
+	t.Run("recovery from panic", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Recovery())
+		f.Use(func() { panic("here is a panic!") })
+		f.Get("/", func() {})
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, "text/html", resp.Header().Get("Content-Type"))
+		assert.Contains(t, resp.Body.String(), "PANIC")
+	})
+
+	t.Run("recovery from panic in non-development mode", func(t *testing.T) {
+		SetEnv(EnvTypeProd)
+		defer SetEnv(EnvTypeDev)
+
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Recovery())
+		f.Use(func() { panic("here is a panic!") })
+		f.Get("/", func() {})
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, "text/plain", resp.Header().Get("Content-Type"))
+		assert.Equal(t, http.StatusText(http.StatusInternalServerError), resp.Body.String())
+	})
+
+	t.Run("Revocery panic to another ResponseWriter", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		resp2 := httptest.NewRecorder()
+
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Recovery())
+		f.Use(func(c Context) {
+			c.MapTo(resp2, (*http.ResponseWriter)(nil))
+			panic("here is a panic!")
+		})
+		f.Get("/", func() {})
+
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp2.Code)
+		assert.Equal(t, "text/html", resp2.Header().Get("Content-Type"))
+		assert.Contains(t, resp2.Body.String(), "PANIC")
+	})
+}


### PR DESCRIPTION
These middleware are migrated from Macaron with minor modifications, this also make the `flamego.Classic` example in README compilable.

**NOTE:** I need to more time thinking about `Static` middleware, so left out from this PR.