### PR TITLE
recovery: use FastInvoker

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/flamego/flamego/internal/inject"
 )
+
+var _ inject.FastInvoker = (*loggerInvoker)(nil)
 
 // loggerInvoker is an inject.FastInvoker implementation of
 // `func(ctx Context, log *log.Logger)`.

--- a/logger.go
+++ b/logger.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+
 	"github.com/flamego/flamego/internal/inject"
 )
 

--- a/recovery.go
+++ b/recovery.go
@@ -121,7 +121,7 @@ pre {
 		return buf.Bytes()
 	}
 
-	return func(c Context, log *log.Logger) {
+	return loggerInvoker(func(c Context, log *log.Logger) {
 		defer func() {
 			if err := recover(); err != nil {
 				stack := stack(3)
@@ -147,5 +147,5 @@ pre {
 		}()
 
 		c.Next()
-	}
+	})
 }


### PR DESCRIPTION
Builtin middleware like `Recovery` should always use the `FastInvoker` to speed up function calls.