### PR TITLE
classic: add `Static` middleware

### DIFF
--- a/flame.go
+++ b/flame.go
@@ -64,13 +64,15 @@ func New() *Flame {
 // flamego.Logger, flamego.Recovery and flamego.Static.
 func Classic() *Flame {
 	f := New()
-	f.Use(Logger())
-	f.Use(Recovery())
-	f.Use(Static(
-		StaticOptions{
-			Directory: "public",
-		},
-	))
+	f.Use(
+		Logger(),
+		Recovery(),
+		Static(
+			StaticOptions{
+				Directory: "public",
+			},
+		),
+	)
 	return f
 }
 
@@ -90,16 +92,17 @@ func (f *Flame) createContext(w http.ResponseWriter, r *http.Request, params rou
 	return c
 }
 
-// Use adds a handler of a middleware to the Flame instance, and panics if the
-// handler is not a callable func. Middleware handlers are invoked in the same
-// order as they are added.
-func (f *Flame) Use(h Handler) {
-	f.handlers = append(f.handlers, validateAndWrapHandler(h, nil))
+// Use adds handlers of middleware to the Flame instance, and panics if any of
+// the handler is not a callable func. Middleware handlers are invoked in the
+// same order as they are added.
+func (f *Flame) Use(handlers ...Handler) {
+	validateAndWrapHandlers(handlers, nil)
+	f.handlers = append(f.handlers, handlers...)
 }
 
 // Handlers sets the entire middleware stack with the given Handlers. This will
 // clear any current middleware handlers, and panics if any of the handlers is
-// not a callable function
+// not a callable function.
 func (f *Flame) Handlers(handlers ...Handler) {
 	f.handlers = make([]Handler, 0, len(handlers))
 	for _, handler := range handlers {

--- a/flame.go
+++ b/flame.go
@@ -61,11 +61,16 @@ func New() *Flame {
 }
 
 // Classic creates and returns a classic Flame instance with default middleware:
-// flamego.Logger, flamego.Recovery and TODO(unknwon): flamego.Static.
+// flamego.Logger, flamego.Recovery and flamego.Static.
 func Classic() *Flame {
 	f := New()
 	f.Use(Logger())
 	f.Use(Recovery())
+	f.Use(Static(
+		StaticOptions{
+			Directory: "public",
+		},
+	))
 	return f
 }
 

--- a/static.go
+++ b/static.go
@@ -1,0 +1,149 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+)
+
+// StaticOptions contains options for the flamego.Static middleware.
+type StaticOptions struct {
+	// Directory is the local directory to be used to serve static file. This value
+	// is ignored when FileSystem is set. Default is the working directory.
+	Directory string
+	// FileSystem is the interface for supporting any implementation of the
+	// http.FileSystem.
+	FileSystem http.FileSystem
+	// Prefix is the optional prefix used to serve the static directory content.
+	Prefix string
+	// Index specifies which file to attempt to serve as the directory index.
+	// Default is "index.html".
+	Index string
+	// Expires is used to set the "Expires" response header for every static file
+	// that is served. Default is not set.
+	Expires func() string
+	// SetETag indicates whether to compute and set "ETag" response header for every
+	// static file that is served. File name, size and modification time are used to
+	// compute the value.
+	SetETag bool
+	// EnableLogging indicates whether to print "[Static]" log messages whenever a
+	// static file is served.
+	EnableLogging bool
+}
+
+func generateETag(size int64, name string, modtime time.Time) string {
+	value := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d%s%s", size, name, modtime.UTC().Format(http.TimeFormat))))
+	return `"` + value + `"`
+}
+
+// Static returns a middleware handler that serves static files in the given
+// directory.
+func Static(opts ...StaticOptions) Handler {
+	var opt StaticOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	parseStaticOptions := func(opts StaticOptions) StaticOptions {
+		if opts.FileSystem == nil {
+			opts.FileSystem = http.Dir(opts.Directory)
+		}
+
+		// Normalize the prefix when provided, we want a leading slash but no trailing
+		// slash ("/").
+		if opts.Prefix != "" {
+			opts.Prefix = "/" + strings.Trim(opts.Prefix, "/")
+		}
+
+		if opts.Index == "" {
+			opts.Index = "index.html"
+		}
+		return opts
+	}
+
+	opt = parseStaticOptions(opt)
+
+	return loggerInvoker(func(c Context, log *log.Logger) {
+		if c.Request().Method != "GET" && c.Request().Method != "HEAD" {
+			return
+		}
+
+		file := c.Request().URL.Path
+		// If we have a prefix set, filter files by stripping the prefix
+		if opt.Prefix != "" {
+			if !strings.HasPrefix(file, opt.Prefix) {
+				return
+			}
+
+			file = file[len(opt.Prefix):]
+			if file != "" && file[0] != '/' {
+				return
+			}
+		}
+
+		f, err := opt.FileSystem.Open(file)
+		if err != nil {
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		fi, err := f.Stat()
+		if err != nil {
+			return // File exists but failed to open.
+		}
+
+		// Try to serve index file
+		if fi.IsDir() {
+			redirPath := path.Clean(c.Request().URL.Path)
+
+			// The path.Clean removes the trailing slash, so we need to add it back when the
+			// original path has it.
+			if strings.HasSuffix(c.Request().URL.Path, "/") {
+				redirPath = redirPath + "/"
+			}
+			// Redirect if missing trailing slash.
+			if !strings.HasSuffix(redirPath, "/") {
+				http.Redirect(c.ResponseWriter(), c.Request().Request, redirPath+"/", http.StatusFound)
+				return
+			}
+
+			file = path.Join(file, opt.Index)
+			f, err := opt.FileSystem.Open(file)
+			if err != nil {
+				return
+			}
+			defer func() { _ = f.Close() }()
+
+			fi, err = f.Stat()
+			if err != nil || fi.IsDir() {
+				return
+			}
+		}
+
+		if opt.EnableLogging {
+			log.Println("[Static] Serving " + file)
+		}
+		if opt.Expires != nil {
+			c.ResponseWriter().Header().Set("Expires", opt.Expires())
+		}
+
+		if opt.SetETag {
+			etag := generateETag(fi.Size(), fi.Name(), fi.ModTime())
+			c.ResponseWriter().Header().Set("ETag", etag)
+			if c.Request().Header.Get("If-None-Match") == etag {
+				c.ResponseWriter().WriteHeader(http.StatusNotModified)
+				return
+			}
+		}
+
+		http.ServeContent(c.ResponseWriter(), c.Request().Request, file, fi.ModTime(), f)
+	})
+}

--- a/static.go
+++ b/static.go
@@ -77,7 +77,7 @@ func Static(opts ...StaticOptions) Handler {
 		}
 
 		file := c.Request().URL.Path
-		// If we have a prefix set, filter files by stripping the prefix
+		// If we have a prefix set, filter files by stripping the prefix.
 		if opt.Prefix != "" {
 			if !strings.HasPrefix(file, opt.Prefix) {
 				return
@@ -100,14 +100,14 @@ func Static(opts ...StaticOptions) Handler {
 			return // File exists but failed to open.
 		}
 
-		// Try to serve index file
+		// Try to serve index file.
 		if fi.IsDir() {
 			redirPath := path.Clean(c.Request().URL.Path)
 
 			// The path.Clean removes the trailing slash, so we need to add it back when the
 			// original path has it.
 			if strings.HasSuffix(c.Request().URL.Path, "/") && !strings.HasSuffix(redirPath, "/") {
-				redirPath = redirPath + "/"
+				redirPath += "/"
 			}
 			// Redirect if missing trailing slash.
 			if !strings.HasSuffix(redirPath, "/") {

--- a/static.go
+++ b/static.go
@@ -106,7 +106,7 @@ func Static(opts ...StaticOptions) Handler {
 
 			// The path.Clean removes the trailing slash, so we need to add it back when the
 			// original path has it.
-			if strings.HasSuffix(c.Request().URL.Path, "/") {
+			if strings.HasSuffix(c.Request().URL.Path, "/") && !strings.HasSuffix(redirPath, "/") {
 				redirPath = redirPath + "/"
 			}
 			// Redirect if missing trailing slash.
@@ -116,16 +116,19 @@ func Static(opts ...StaticOptions) Handler {
 			}
 
 			file = path.Join(file, opt.Index)
-			f, err := opt.FileSystem.Open(file)
+			index, err := opt.FileSystem.Open(file)
 			if err != nil {
 				return
 			}
-			defer func() { _ = f.Close() }()
+			defer func() { _ = index.Close() }()
 
-			fi, err = f.Stat()
+			fi, err = index.Stat()
 			if err != nil || fi.IsDir() {
 				return
 			}
+
+			_ = f.Close()
+			f = index
 		}
 
 		if opt.EnableLogging {

--- a/static_test.go
+++ b/static_test.go
@@ -139,7 +139,7 @@ func TestStatic_Options(t *testing.T) {
 				))
 
 				resp := httptest.NewRecorder()
-				req, err := http.NewRequest("HEAD", test.url, nil)
+				req, err := http.NewRequest("GET", test.url, nil)
 				assert.Nil(t, err)
 
 				f.ServeHTTP(resp, req)

--- a/static_test.go
+++ b/static_test.go
@@ -1,0 +1,273 @@
+// Copyright 2021 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatic(t *testing.T) {
+	f := NewWithLogger(&bytes.Buffer{})
+	f.Use(Static())
+
+	t.Run("serve with GET", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Empty(t, resp.Header().Get("Expires"))
+		assert.NotEmpty(t, resp.Body.String())
+	})
+
+	t.Run("serve with HEAD", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("HEAD", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Empty(t, resp.Header().Get("Expires"))
+		assert.Empty(t, resp.Body.String())
+	})
+
+	t.Run("404 with POST", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
+}
+
+func TestStatic_Options(t *testing.T) {
+	t.Run("custom FileSystem", func(t *testing.T) {
+		mockFS := &fstest.MapFS{
+			"hello.txt": {
+				Data: []byte("hello, world"),
+			},
+		}
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				FileSystem: http.FS(mockFS),
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/hello.txt", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "hello, world", resp.Body.String())
+	})
+
+	t.Run("prefix", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				Prefix: "public",
+			},
+		))
+
+		tests := []struct {
+			url            string
+			wantStatusCode int
+		}{
+			{
+				url:            "/public/.editorconfig",
+				wantStatusCode: http.StatusOK,
+			},
+			{
+				url:            "/.editorconfig",
+				wantStatusCode: http.StatusNotFound,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.url, func(t *testing.T) {
+				resp := httptest.NewRecorder()
+				req, err := http.NewRequest("HEAD", test.url, nil)
+				assert.Nil(t, err)
+
+				f.ServeHTTP(resp, req)
+
+				assert.Equal(t, test.wantStatusCode, resp.Code)
+			})
+		}
+	})
+
+	t.Run("index", func(t *testing.T) {
+		tests := []struct {
+			url            string
+			index          string
+			wantStatusCode int
+		}{
+			{
+				url:            "/",
+				index:          ".editorconfig",
+				wantStatusCode: http.StatusOK,
+			},
+			{
+				url:            "/",
+				index:          "index.html",
+				wantStatusCode: http.StatusNotFound,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.index, func(t *testing.T) {
+				f := NewWithLogger(&bytes.Buffer{})
+				f.Use(Static(
+					StaticOptions{
+						Index: test.index,
+					},
+				))
+
+				resp := httptest.NewRecorder()
+				req, err := http.NewRequest("HEAD", test.url, nil)
+				assert.Nil(t, err)
+
+				f.ServeHTTP(resp, req)
+
+				assert.Equal(t, test.wantStatusCode, resp.Code)
+			})
+		}
+	})
+
+	t.Run("expires", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				Expires: func() string {
+					return "2830"
+				},
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("HEAD", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "2830", resp.Header().Get("Expires"))
+	})
+
+	t.Run("etag", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				SetETag: true,
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+
+		lastModified, err := time.Parse(http.TimeFormat, resp.Header().Get("Last-Modified"))
+		assert.Nil(t, err)
+
+		etag := generateETag(int64(resp.Body.Len()), ".editorconfig", lastModified)
+		assert.Equal(t, etag, resp.Header().Get("ETag"))
+	})
+
+	t.Run("etag with If-None-Match", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				SetETag: true,
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+
+		lastModified, err := time.Parse(http.TimeFormat, resp.Header().Get("Last-Modified"))
+		assert.Nil(t, err)
+		etag := generateETag(int64(resp.Body.Len()), ".editorconfig", lastModified)
+
+		// Second request with ETag in If-None-Match
+		resp = httptest.NewRecorder()
+		req.Header.Add("If-None-Match", etag)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotModified, resp.Code)
+	})
+}
+
+func TestStatic_Redirect(t *testing.T) {
+	t.Run("serve with prefix but without redirect", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				Prefix: "/public",
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/public/", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
+
+	t.Run("serve with redirect", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				Prefix: "/public",
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/public", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusFound, resp.Code)
+		assert.Equal(t, "/public/", resp.Header().Get("Location"))
+	})
+
+	t.Run("serve with improper request", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static())
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "http://localhost:2830//example.com%2f..", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
+}

--- a/static_test.go
+++ b/static_test.go
@@ -6,7 +6,6 @@ package flamego
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -137,13 +136,12 @@ func TestStatic_Options(t *testing.T) {
 				))
 
 				resp := httptest.NewRecorder()
-				req, err := http.NewRequest("GET", "/", nil)
+				req, err := http.NewRequest("HEAD", "/", nil)
 				assert.Nil(t, err)
 
 				f.ServeHTTP(resp, req)
 
 				assert.Equal(t, test.wantStatusCode, resp.Code)
-				fmt.Println(resp.Body.String())
 			})
 		}
 	})

--- a/static_test.go
+++ b/static_test.go
@@ -6,6 +6,7 @@ package flamego
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -145,7 +146,7 @@ func TestStatic_Options(t *testing.T) {
 				f.ServeHTTP(resp, req)
 
 				assert.Equal(t, test.wantStatusCode, resp.Code)
-				assert.Empty(t, resp.Body.String())
+				fmt.Println(resp.Body.String())
 			})
 		}
 	})

--- a/static_test.go
+++ b/static_test.go
@@ -115,17 +115,14 @@ func TestStatic_Options(t *testing.T) {
 
 	t.Run("index", func(t *testing.T) {
 		tests := []struct {
-			url            string
 			index          string
 			wantStatusCode int
 		}{
 			{
-				url:            "/",
 				index:          ".editorconfig",
 				wantStatusCode: http.StatusOK,
 			},
 			{
-				url:            "/",
 				index:          "index.html",
 				wantStatusCode: http.StatusNotFound,
 			},
@@ -140,7 +137,7 @@ func TestStatic_Options(t *testing.T) {
 				))
 
 				resp := httptest.NewRecorder()
-				req, err := http.NewRequest("GET", test.url, nil)
+				req, err := http.NewRequest("GET", "/", nil)
 				assert.Nil(t, err)
 
 				f.ServeHTTP(resp, req)

--- a/static_test.go
+++ b/static_test.go
@@ -145,6 +145,7 @@ func TestStatic_Options(t *testing.T) {
 				f.ServeHTTP(resp, req)
 
 				assert.Equal(t, test.wantStatusCode, resp.Code)
+				assert.Empty(t, resp.Body.String())
 			})
 		}
 	})


### PR DESCRIPTION
This PR migrated `Static` middleware from Macaron with Go 1.16 features.