### PR TITLE
context: respect request context cancellation

### DIFF
--- a/context.go
+++ b/context.go
@@ -166,6 +166,13 @@ func ordinalize(number int) string {
 
 func (c *context) run() {
 	for c.index <= len(c.handlers) {
+		// Break out when the request context has been cancelled
+		select {
+		case <-c.Request().Context().Done():
+			return
+		default:
+		}
+
 		var h Handler
 		if c.index == len(c.handlers) {
 			h = c.action

--- a/context_test.go
+++ b/context_test.go
@@ -6,6 +6,7 @@ package flamego
 
 import (
 	"bytes"
+	gocontext "context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestContext_RequestContextCancel(t *testing.T) {
+	ctx, cancel := gocontext.WithCancel(gocontext.Background())
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+	assert.Nil(t, err)
+
+	f := NewWithLogger(&bytes.Buffer{})
+	f.Get("/",
+		func() { cancel() },
+		func() { assert.Fail(t, "should not be called") },
+	)
+
+	f.ServeHTTP(resp, req)
+}
 
 func TestContext_URLPath(t *testing.T) {
 	f := NewWithLogger(&bytes.Buffer{})


### PR DESCRIPTION
If the request has been cancelled on the client side, there is no point wasting server computing power to continue invoking subsequent handlers.