### PR TITLE
return_handler: support returning error with custom status code

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -23,7 +23,7 @@ type ResponseWriter interface {
 	// Status returns the status code of the response or 0 if the response has not
 	// been written.
 	Status() int
-	// Written returns whether or not the ResponseWriter has been written.
+	// Written returns whether the ResponseWriter has been written.
 	Written() bool
 	// Size returns the written size of the response body.
 	Size() int
@@ -61,6 +61,10 @@ func (w *responseWriter) callBefore() {
 }
 
 func (w *responseWriter) WriteHeader(s int) {
+	if w.Written() {
+		return
+	}
+
 	w.callBefore()
 	w.ResponseWriter.WriteHeader(s)
 	w.status = s

--- a/return_handler_test.go
+++ b/return_handler_test.go
@@ -23,7 +23,7 @@ func TestReturnHandler(t *testing.T) {
 		{
 			name: "(int, string)",
 			handler: func() (int, string) {
-				return 418, "i'm a teapot"
+				return http.StatusTeapot, "i'm a teapot"
 			},
 			wantCode: http.StatusTeapot,
 			wantBody: "i'm a teapot",
@@ -31,10 +31,18 @@ func TestReturnHandler(t *testing.T) {
 		{
 			name: "(int, []byte)",
 			handler: func() (int, []byte) {
-				return 418, []byte("i'm a teapot")
+				return http.StatusTeapot, []byte("i'm a teapot")
 			},
 			wantCode: http.StatusTeapot,
 			wantBody: "i'm a teapot",
+		},
+		{
+			name: "(int, error)",
+			handler: func() (int, error) {
+				return http.StatusForbidden, errors.New("teapot on the phone")
+			},
+			wantCode: http.StatusForbidden,
+			wantBody: "teapot on the phone",
 		},
 		{
 			name: "string",


### PR DESCRIPTION
### Describe the pull request

This PR adds the ability to use `(int, error)` as return values of a handler, which allows returning an error with custom status code. Previously it was always using 500.

Link to the issue: n/a

### Checklist

- [x] I have added test cases to cover the new code.
- [x] I agree to follow this project's [Code of Conduct](https://golang.org/conduct) by submitting this pull request.
