### PR TITLE
route: fix optional static routes not matching

### DIFF
--- a/internal/route/leaf.go
+++ b/internal/route/leaf.go
@@ -116,6 +116,7 @@ func (l *baseLeaf) Static() bool {
 // staticLeaf is a leaf with a static match style.
 type staticLeaf struct {
 	baseLeaf
+	literals string
 }
 
 func (l *staticLeaf) getMatchStyle() MatchStyle {
@@ -123,7 +124,7 @@ func (l *staticLeaf) getMatchStyle() MatchStyle {
 }
 
 func (l *staticLeaf) match(segment string, _ Params) bool {
-	return l.segment.String()[1:] == segment // Skip the leading "/"
+	return l.literals == segment
 }
 
 func (l *staticLeaf) Static() bool {
@@ -310,6 +311,7 @@ func newLeaf(parent Tree, r *Route, s *Segment, h Handler) (Leaf, error) {
 				segment: s,
 				handler: h,
 			},
+			literals: strings.TrimLeft(s.String(), "/?"),
 		}, nil
 	}
 

--- a/internal/route/leaf_test.go
+++ b/internal/route/leaf_test.go
@@ -31,7 +31,9 @@ func TestNewLeaf(t *testing.T) {
 		{
 			route: "/webapi",
 			style: matchStyleStatic,
-			want:  &staticLeaf{},
+			want: &staticLeaf{
+				literals: "webapi",
+			},
 		},
 		{
 			route: "/{name}",

--- a/internal/route/tree_test.go
+++ b/internal/route/tree_test.go
@@ -174,6 +174,7 @@ func TestAddRoute(t *testing.T) {
 			wantDepth: 2,
 			wantLeaf: &staticLeaf{
 				baseLeaf: baseLeaf{},
+				literals: "webapi",
 			},
 		},
 		{
@@ -182,6 +183,7 @@ func TestAddRoute(t *testing.T) {
 			wantDepth: 3,
 			wantLeaf: &staticLeaf{
 				baseLeaf: baseLeaf{},
+				literals: "name",
 			},
 		},
 		{
@@ -208,6 +210,7 @@ func TestAddRoute(t *testing.T) {
 			wantDepth: 5,
 			wantLeaf: &staticLeaf{
 				baseLeaf: baseLeaf{},
+				literals: "edit",
 			},
 		},
 		{
@@ -347,6 +350,7 @@ func TestTree_Match(t *testing.T) {
 		"/webapi/users/ids/{sha: /[a-z0-9]{7,40}/}",
 		"/webapi/users/sessions/{paths: **}",
 		"/webapi/users/events/{names: **}/feed",
+		"/webapi/users/settings/?profile",
 		"/webapi/projects/{name}/hashes/{paths: **, capture: 2}/blob/{lineno: /[0-9]+/}",
 		"/webapi/projects/{name}/commit/{sha: /[a-z0-9]{7,40}/}/main.go",
 		`/webapi/projects/{name}/commit/{sha: /[a-z0-9]{7,40}/}{ext: /(\.(patch|diff))?/}`,
@@ -482,6 +486,17 @@ func TestTree_Match(t *testing.T) {
 			path:       "/webapi/special/%_",
 			wantOK:     true,
 			wantParams: Params{},
+		},
+		{
+			path:       "/webapi/users/settings",
+			wantOK:     true,
+			wantParams: Params{},
+		},
+		{
+			path:         "/webapi/users/settings/profile",
+			withOptional: true,
+			wantOK:       true,
+			wantParams:   Params{},
 		},
 
 		// No match


### PR DESCRIPTION
### Describe the pull request

This PR fixes the optional static routes are not matching, e.g. the following route gives 404 on requesting `GET /users/settings`:

```go
f.Get("/users/?settings", ...)
```

Dynamic optional routes are working correctly.

Link to the issue: n/a

### Checklist

- [x] I have added test cases to cover the new code.
- [x] I agree to follow this project's [Code of Conduct](https://golang.org/conduct) by submitting this pull request.
