### PR TITLE
router: fix slash path trimming

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -234,6 +234,22 @@ func TestContext_Param(t *testing.T) {
 			},
 			wantBody: "hello 123",
 		},
+		{
+			route: "/params/{**: **}",
+			url:   "/params/hello/123/",
+			handler: func(c Context) string {
+				return fmt.Sprintf("%s", c.Param("**"))
+			},
+			wantBody: "hello/123/",
+		},
+		{
+			route: "/{**: **}",
+			url:   "///////hello/123//////////////",
+			handler: func(c Context) string {
+				return fmt.Sprintf("%s", c.Param("**"))
+			},
+			wantBody: "hello/123//////////////",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -238,7 +238,7 @@ func TestContext_Param(t *testing.T) {
 			route: "/params/{**: **}",
 			url:   "/params/hello/123/",
 			handler: func(c Context) string {
-				return fmt.Sprintf("%s", c.Param("**"))
+				return c.Param("**")
 			},
 			wantBody: "hello/123/",
 		},
@@ -246,7 +246,7 @@ func TestContext_Param(t *testing.T) {
 			route: "/{**: **}",
 			url:   "///////hello/123//////////////",
 			handler: func(c Context) string {
-				return fmt.Sprintf("%s", c.Param("**"))
+				return c.Param("**")
 			},
 			wantBody: "hello/123//////////////",
 		},

--- a/internal/route/tree.go
+++ b/internal/route/tree.go
@@ -476,7 +476,7 @@ func (t *baseTree) matchNextSegment(path string, next int, params Params) (Leaf,
 }
 
 func (t *baseTree) Match(path string) (Leaf, Params, bool) {
-	path = strings.Trim(path, "/")
+	path = strings.TrimLeft(path, "/")
 	params := make(Params)
 	leaf, ok := t.matchNextSegment(path, 0, params)
 	if !ok {

--- a/internal/route/tree_test.go
+++ b/internal/route/tree_test.go
@@ -380,11 +380,6 @@ func TestTree_Match(t *testing.T) {
 			wantParams: Params{},
 		},
 		{
-			path:       "/webapi//",
-			wantOK:     false,
-			wantParams: Params{},
-		},
-		{
 			path:       "/webapi/users",
 			wantOK:     true,
 			wantParams: Params{},
@@ -500,6 +495,10 @@ func TestTree_Match(t *testing.T) {
 		},
 
 		// No match
+		{
+			path:   "/webapi//", // the last slash is a new route segment
+			wantOK: false,
+		},
 		{
 			path:   "/webapi/users/ids/abc", // "abc" are not digits
 			wantOK: false,

--- a/internal/route/tree_test.go
+++ b/internal/route/tree_test.go
@@ -381,7 +381,7 @@ func TestTree_Match(t *testing.T) {
 		},
 		{
 			path:       "/webapi//",
-			wantOK:     true,
+			wantOK:     false,
 			wantParams: Params{},
 		},
 		{


### PR DESCRIPTION
### Describe the pull request

Fix the wrong path trimming behavior, which makes route `/{**: **}` can get the correct parameter value when there is a slash at the end of the path.

Link to the issue: https://github.com/flamego/flamego/issues/75

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
