### PR TITLE
router: support `{**}` as the shorthand for `{**: **}`

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -243,6 +243,14 @@ func TestContext_Param(t *testing.T) {
 			wantBody: "hello/123/",
 		},
 		{
+			route: "/apps/{**}",
+			url:   "/apps/hello/123/",
+			handler: func(c Context) string {
+				return c.Param("**")
+			},
+			wantBody: "hello/123/",
+		},
+		{
 			route: "/{**: **}",
 			url:   "///////hello/123//////////////",
 			handler: func(c Context) string {

--- a/internal/route/leaf_test.go
+++ b/internal/route/leaf_test.go
@@ -49,6 +49,13 @@ func TestNewLeaf(t *testing.T) {
 				bind: "paths",
 			},
 		},
+		{
+			route: "/{**}",
+			style: matchStyleAll,
+			want: &matchAllLeaf{
+				bind: "**",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {


### PR DESCRIPTION
### Describe the pull request

Link to the issue: https://github.com/flamego/flamego/issues/71

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
