### PR TITLE
return_handler: support return values of `({string, []byte}, error)`

### DIFF
--- a/return_handler_test.go
+++ b/return_handler_test.go
@@ -44,6 +44,40 @@ func TestReturnHandler(t *testing.T) {
 			wantCode: http.StatusForbidden,
 			wantBody: "teapot on the phone",
 		},
+
+		{
+			name: "(string, error)",
+			handler: func() (string, error) {
+				return "", errors.New("teapot on the phone")
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: "teapot on the phone",
+		},
+		{
+			name: "(string, nil-error)",
+			handler: func() (string, error) {
+				return "i'm a teapot", nil
+			},
+			wantCode: http.StatusOK,
+			wantBody: "i'm a teapot",
+		},
+		{
+			name: "([]byte, error)",
+			handler: func() ([]byte, error) {
+				return []byte(""), errors.New("teapot on the phone")
+			},
+			wantCode: http.StatusInternalServerError,
+			wantBody: "teapot on the phone",
+		},
+		{
+			name: "([]byte, nil-error)",
+			handler: func() ([]byte, error) {
+				return []byte("i'm a teapot"), nil
+			},
+			wantCode: http.StatusOK,
+			wantBody: "i'm a teapot",
+		},
+
 		{
 			name: "string",
 			handler: func() string {


### PR DESCRIPTION
### Describe the pull request

Both `(string, error)` and `([]byte, error)` are reasonable pairs of return values.

Link to the issue: https://github.com/flamego/flamego/issues/117

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.

### Followups

- [ ] Update docs to include all possible combinations of return values