### PR TITLE
response_writer: make read and write status code thread safe

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [ 1.16.x, 1.17.x ]
+        go-version: [ 1.16.x, 1.17.x, 1.18.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
 
 comment:
   layout: 'diff'
+
+github_checks: false


### PR DESCRIPTION
### Describe the pull request

Read / write operations of status code was not thread-safe which causes problem when a middleware responds data to the client asynchronously.

Link to the issue: https://github.com/flamego/sse/pull/1

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
