### PR TITLE
router: support `Routes` accepting multiple strings as method

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@
 package flamego
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -52,7 +53,7 @@ func (invoke teapotInvoker) Invoke([]interface{}) ([]reflect.Value, error) {
 // gain up to 3x performance improvement.
 func validateAndWrapHandler(h Handler, wrapper func(Handler) Handler) Handler {
 	if reflect.TypeOf(h).Kind() != reflect.Func {
-		panic("handler must be a callable function")
+		panic(fmt.Sprintf("handler must be a callable function, but got %T", h))
 	}
 
 	if inject.IsFastInvoker(h) {

--- a/router_test.go
+++ b/router_test.go
@@ -125,23 +125,46 @@ func TestRouter_Routes(t *testing.T) {
 		})
 		return ctx
 	}
-	r := newRouter(contextCreator)
 
-	r.Routes("/routes", "GET,POST", func() {})
+	t.Run("use single string", func(t *testing.T) {
+		r := newRouter(contextCreator)
 
-	for _, m := range []string{http.MethodGet, http.MethodPost} {
-		gotRoute := ""
-		ctx.run_ = func() { gotRoute = ctx.Param("route") }
+		r.Routes("/routes", "GET,POST", func() {})
 
-		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(m, "/routes", nil)
-		assert.Nil(t, err)
+		for _, m := range []string{http.MethodGet, http.MethodPost} {
+			gotRoute := ""
+			ctx.run_ = func() { gotRoute = ctx.Param("route") }
 
-		r.ServeHTTP(resp, req)
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(m, "/routes", nil)
+			assert.Nil(t, err)
 
-		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, "/routes", gotRoute)
-	}
+			r.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "/routes", gotRoute)
+		}
+	})
+
+	t.Run("use multiple strings", func(t *testing.T) {
+		r := newRouter(contextCreator)
+
+		r.Routes("/routes", http.MethodGet, http.MethodPost, func() {})
+
+		for _, m := range []string{http.MethodGet, http.MethodPost} {
+			gotRoute := ""
+			ctx.run_ = func() { gotRoute = ctx.Param("route") }
+
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(m, "/routes", nil)
+			assert.Nil(t, err)
+
+			r.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "/routes", gotRoute)
+		}
+	})
 }
 
 func TestRouter_AutoHead(t *testing.T) {


### PR DESCRIPTION
### Describe the pull request

Link to the issue: https://github.com/flamego/flamego/issues/113

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
