### PR TITLE
route: add `Headers` method for matching request headers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,10 @@ coverage:
       default:
         threshold: 1%
         informational: true
+    patch:
+      default:
+        only_pulls: true
+        informational: true
 
 comment:
   layout: 'diff'

--- a/internal/route/header_matcher.go
+++ b/internal/route/header_matcher.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package route
+
+import (
+	"net/http"
+	"regexp"
+)
+
+// HeaderMatcher stores matchers for request headers.
+type HeaderMatcher struct {
+	matches map[string]*regexp.Regexp // Key is the header name
+}
+
+// NewHeaderMatcher creates a new HeaderMatcher using given matches, where keys
+// are header names.
+func NewHeaderMatcher(matches map[string]*regexp.Regexp) *HeaderMatcher {
+	return &HeaderMatcher{
+		matches: matches,
+	}
+}
+
+// Match returns true if all matches are successfully in the given header.
+func (m *HeaderMatcher) Match(header http.Header) bool {
+	for name, re := range m.matches {
+		v := header.Get(name)
+		if v == "" {
+			return false
+		}
+		if !re.MatchString(v) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/route/header_matcher_test.go
+++ b/internal/route/header_matcher_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package route
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderMatcher(t *testing.T) {
+	header := make(http.Header)
+	header.Set("Server", "Caddy")
+	header.Set("Status", "200 OK")
+
+	tests := []struct {
+		name    string
+		matches map[string]*regexp.Regexp
+		want    bool
+	}{
+		{
+			name: "loose matches",
+			matches: map[string]*regexp.Regexp{
+				"Server": regexp.MustCompile("Caddy"),
+				"Status": regexp.MustCompile("200"),
+			},
+			want: true,
+		},
+		{
+			name: "loose matches",
+			matches: map[string]*regexp.Regexp{
+				"Server": regexp.MustCompile("Caddy"),
+				"Status": regexp.MustCompile("404"),
+			},
+			want: false,
+		},
+
+		{
+			name: "exact matches",
+			matches: map[string]*regexp.Regexp{
+				"Server": regexp.MustCompile("^Caddy$"),
+				"Status": regexp.MustCompile("^200 OK$"),
+			},
+			want: true,
+		},
+		{
+			name: "exact matches",
+			matches: map[string]*regexp.Regexp{
+				"Server": regexp.MustCompile("^Caddy$"),
+				"Status": regexp.MustCompile("^200$"),
+			},
+			want: false,
+		},
+
+		{
+			name: "presence match",
+			matches: map[string]*regexp.Regexp{
+				"Server": regexp.MustCompile(""),
+			},
+			want: true,
+		},
+		{
+			name: "presence match",
+			matches: map[string]*regexp.Regexp{
+				"Server":        regexp.MustCompile(""),
+				"Cache-Control": regexp.MustCompile(""),
+			},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := NewHeaderMatcher(test.matches).Match(header)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/route/leaf_test.go
+++ b/internal/route/leaf_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewLeaf(t *testing.T) {
@@ -21,7 +22,7 @@ func TestNewLeaf(t *testing.T) {
 	})
 
 	parser, err := NewParser()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		route string
@@ -60,12 +61,12 @@ func TestNewLeaf(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {
 			route, err := parser.Parse(test.route)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Len(t, route.Segments, 1)
 
 			segment := route.Segments[0]
 			got, err := newLeaf(nil, route, segment, nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			switch test.style {
 			case matchStyleStatic:
@@ -86,7 +87,7 @@ func TestNewLeaf(t *testing.T) {
 
 func TestNewLeaf_Regex(t *testing.T) {
 	parser, err := NewParser()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		route      string
@@ -122,12 +123,12 @@ func TestNewLeaf_Regex(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {
 			route, err := parser.Parse(test.route)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Len(t, route.Segments, 1)
 
 			segment := route.Segments[0]
 			got, err := newLeaf(nil, route, segment, nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			leaf := got.(*regexLeaf)
 			assert.Equal(t, test.wantRegexp, leaf.regexp.String())
@@ -138,7 +139,7 @@ func TestNewLeaf_Regex(t *testing.T) {
 
 func TestLeaf_URLPath(t *testing.T) {
 	parser, err := NewParser()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		route        string
@@ -245,11 +246,11 @@ func TestLeaf_URLPath(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {
 			route, err := parser.Parse(test.route)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			segment := route.Segments[len(route.Segments)-1]
 			leaf, err := newLeaf(nil, route, segment, nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			got := leaf.URLPath(test.vals, test.withOptional)
 			assert.Equal(t, test.want, got)

--- a/internal/route/tree_test.go
+++ b/internal/route/tree_test.go
@@ -665,8 +665,18 @@ func TestTree_MatchHeader(t *testing.T) {
 			"Server": "Caddy",
 		},
 	)
-	// 	"/webapi/users/events/{names: **}/feed",
-	// 	"/webapi/groups/{name: **, capture: 2}",
+
+	addRoute("/webapi/users/events/{names: **}/feed",
+		map[string]string{
+			"Server": "Caddy",
+			"Status": "",
+		},
+	)
+	addRoute("/webapi/users/events/{names: **}",
+		map[string]string{
+			"Server": "Caddy",
+		},
+	)
 
 	tests := []struct {
 		path       string
@@ -753,6 +763,28 @@ func TestTree_MatchHeader(t *testing.T) {
 			},
 			wantOK:     true,
 			wantParams: Params{},
+		},
+
+		{
+			path: "/webapi/users/events/push/feed",
+			header: map[string]string{
+				"Server": "Caddy",
+			},
+			wantOK: true,
+			wantParams: Params{
+				"names": "push/feed", // Not matching "/webapi/users/events/{names: **}/feed" because missing "Status" header
+			},
+		},
+		{
+			path: "/webapi/users/events/push/feed",
+			header: map[string]string{
+				"Server": "Caddy",
+				"Status": "200 OK",
+			},
+			wantOK: true,
+			wantParams: Params{
+				"names": "push",
+			},
 		},
 	}
 	for _, test := range tests {

--- a/router.go
+++ b/router.go
@@ -146,9 +146,9 @@ type Route struct {
 //
 // For example:
 //  f.Get("/", ...).Headers(
-//      "Server", "Caddy",    // Loose match
-//      "Status", "^200 OK$", // Exact match
-//      "Cache-Control", "",  // As long as "Cache-Control" is not empty
+//      "User-Agent", "Chrome",   // Loose match
+//      "Host", "^flamego\.dev$", // Exact match
+//      "Cache-Control", "",      // As long as "Cache-Control" is not empty
 //  )
 //
 // Subsequent calls to Headers() replace previously set matches.

--- a/router.go
+++ b/router.go
@@ -7,6 +7,7 @@ package flamego
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/flamego/flamego/internal/route"
@@ -132,10 +133,43 @@ func (r *router) HandlerWrapper(f func(Handler) Handler) {
 	r.handlerWrapper = f
 }
 
-// Route is a wrapper of the route leaf and its router.
+// Route is a wrapper of the route leaves and its router.
 type Route struct {
 	router *router
-	leaf   route.Leaf
+	leaves map[string]route.Leaf
+}
+
+// Headers uses given key-value pairs as the list of matching criteria for
+// request headers, where key is the header name and value is a regex. Once set,
+// the route will only be matched if all header matches are successful in
+// addition to the request path.
+//
+// For example:
+//  f.Get("/", ...).Headers(
+//      "Server", "Caddy",    // Loose match
+//      "Status", "^200 OK$", // Exact match
+//      "Cache-Control", "",  // As long as "Cache-Control" is not empty
+//  )
+//
+// Subsequent calls to Headers() replace previously set matches.
+func (r *Route) Headers(pairs ...string) *Route {
+	if len(pairs)%2 != 0 {
+		panic(fmt.Sprintf("imbalanced pairs with %d", len(pairs)))
+	}
+
+	matches := make(map[string]*regexp.Regexp, len(pairs)/2)
+	for i := 1; i < len(pairs); i += 2 {
+		matches[pairs[i-1]] = regexp.MustCompile(pairs[i])
+	}
+	for m, leaf := range r.leaves {
+		leaf.SetHeaderMatcher(route.NewHeaderMatcher(matches))
+
+		// Delete static route from fast paths since header matches are dynamic.
+		if leaf.Static() {
+			delete(r.router.staticRoutes[m], leaf.Route())
+		}
+	}
+	return r
 }
 
 // Name sets the name for the route.
@@ -145,7 +179,11 @@ func (r *Route) Name(name string) {
 	} else if _, ok := r.router.namedRoutes[name]; ok {
 		panic("duplicated route name: " + name)
 	}
-	r.router.namedRoutes[name] = r.leaf
+
+	for _, leaf := range r.leaves {
+		r.router.namedRoutes[name] = leaf
+		break
+	}
 }
 
 func (r *router) addRoute(method, routePath string, handler route.Handler) *Route {
@@ -171,9 +209,9 @@ func (r *router) addRoute(method, routePath string, handler route.Handler) *Rout
 		panic(fmt.Sprintf("unable to parse route %q: %v", routePath, err))
 	}
 
-	var leaf route.Leaf
+	leaves := make(map[string]route.Leaf, len(methods))
 	for _, m := range methods {
-		leaf, err = route.AddRoute(r.routeTrees[m], ast, handler)
+		leaf, err := route.AddRoute(r.routeTrees[m], ast, handler)
 		if err != nil {
 			panic(fmt.Sprintf("unable to add route %q with method %s: %v", routePath, m, err))
 		}
@@ -181,11 +219,12 @@ func (r *router) addRoute(method, routePath string, handler route.Handler) *Rout
 		if leaf.Static() {
 			r.staticRoutes[m][leaf.Route()] = leaf
 		}
+		leaves[m] = leaf
 	}
 
 	return &Route{
 		router: r,
-		leaf:   leaf,
+		leaves: leaves,
 	}
 }
 
@@ -319,7 +358,7 @@ func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	leaf, params, ok := routeTree.Match(req.URL.Path)
+	leaf, params, ok := routeTree.Match(req.URL.Path, req.Header)
 	if !ok {
 		r.notFound(w, req)
 		return

--- a/router_test.go
+++ b/router_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/flamego/flamego/internal/route"
 )
@@ -35,7 +36,7 @@ func TestRouter_Route(t *testing.T) {
 	t.Run("request with invalid HTTP method", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest("UNEXPECTED", "/", nil)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		ctx.run_ = func() {}
 		r.ServeHTTP(resp, req)
@@ -107,7 +108,7 @@ func TestRouter_Route(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(test.method, test.routePath, nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			r.ServeHTTP(resp, req)
 
@@ -137,7 +138,7 @@ func TestRouter_Routes(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(m, "/routes", nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			r.ServeHTTP(resp, req)
 
@@ -157,7 +158,7 @@ func TestRouter_Routes(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(m, "/routes", nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			r.ServeHTTP(resp, req)
 
@@ -185,7 +186,7 @@ func TestRouter_AutoHead(t *testing.T) {
 
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodHead, "/", nil)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		r.ServeHTTP(resp, req)
 
@@ -203,7 +204,7 @@ func TestRouter_AutoHead(t *testing.T) {
 
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodHead, "/", nil)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		r.ServeHTTP(resp, req)
 
@@ -224,6 +225,34 @@ func TestRouter_DuplicatedRoutes(t *testing.T) {
 		assert.Contains(t, recover(), "duplicated route")
 	}()
 	r.Get("/", func() {})
+}
+
+func TestRoute_Headers(t *testing.T) {
+	f := New()
+	f.Get("/", func() {}).Headers("Server", "Caddy", "Cache-Control", "")
+
+	t.Run("ok", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Server", "Caddy")
+		req.Header.Set("Cache-Control", "No-Cache")
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Server", "Caddy")
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
 }
 
 func TestRoute_Name(t *testing.T) {
@@ -324,7 +353,7 @@ func TestRouter_Group(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(http.MethodGet, route, nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			r.ServeHTTP(resp, req)
 
@@ -362,7 +391,7 @@ func TestComboRoute(t *testing.T) {
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest(m, "/", nil)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			r.ServeHTTP(resp, req)
 


### PR DESCRIPTION
### Describe the pull request

Use regex to match headers!

Link to the issue: fixes https://github.com/flamego/flamego/issues/132

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.

### Followup

- [ ] Update docs on flamego.dev
- [ ] Update docs on flamego.cn