### PR TITLE
static: support setting "Cache-Control"

### DIFF
--- a/static.go
+++ b/static.go
@@ -37,8 +37,8 @@ type StaticOptions struct {
 	// EnableLogging indicates whether to print "[Static]" log messages whenever a
 	// static file is served.
 	EnableLogging bool
-	// CacheControl specifies the Cache-Control header value to be used when serving
-	// static files.
+	// CacheControl is used to set the "Cache-Control" response header for every
+	// static file that is served. Default is not set.
 	CacheControl func() string
 }
 

--- a/static.go
+++ b/static.go
@@ -37,6 +37,9 @@ type StaticOptions struct {
 	// EnableLogging indicates whether to print "[Static]" log messages whenever a
 	// static file is served.
 	EnableLogging bool
+	// CacheControl specifies the Cache-Control header value to be used when serving
+	// static files.
+	CacheControl func() string
 }
 
 func generateETag(size int64, name string, modtime time.Time) string {
@@ -140,6 +143,9 @@ func Static(opts ...StaticOptions) Handler {
 		}
 		if opt.Expires != nil {
 			c.ResponseWriter().Header().Set("Expires", opt.Expires())
+		}
+		if opt.CacheControl != nil {
+			c.ResponseWriter().Header().Set("Cache-Control", opt.CacheControl())
 		}
 
 		if opt.SetETag {

--- a/static_test.go
+++ b/static_test.go
@@ -174,13 +174,13 @@ func TestStatic_Options(t *testing.T) {
 	})
 
 	t.Run("cache-control", func(t *testing.T) {
-		__cacheControl := "public, max-age=60"
+		const cacheControl = "public, max-age=60"
 		f := NewWithLogger(&bytes.Buffer{})
 		f.Use(Static(
 			StaticOptions{
 				Directory: ".",
 				CacheControl: func() string {
-					return __cacheControl
+					return cacheControl
 				},
 			},
 		))
@@ -192,7 +192,7 @@ func TestStatic_Options(t *testing.T) {
 		f.ServeHTTP(resp, req)
 
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, __cacheControl, resp.Header().Get("Cache-Control"))
+		assert.Equal(t, cacheControl, resp.Header().Get("Cache-Control"))
 	})
 
 	t.Run("etag", func(t *testing.T) {

--- a/static_test.go
+++ b/static_test.go
@@ -173,6 +173,28 @@ func TestStatic_Options(t *testing.T) {
 		assert.Equal(t, "2830", resp.Header().Get("Expires"))
 	})
 
+	t.Run("cache-control", func(t *testing.T) {
+		__cacheControl := "public, max-age=60"
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Static(
+			StaticOptions{
+				Directory: ".",
+				CacheControl: func() string {
+					return __cacheControl
+				},
+			},
+		))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodHead, "/.editorconfig", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, __cacheControl, resp.Header().Get("Cache-Control"))
+	})
+
 	t.Run("etag", func(t *testing.T) {
 		f := NewWithLogger(&bytes.Buffer{})
 		f.Use(Static(

--- a/static_test.go
+++ b/static_test.go
@@ -186,7 +186,7 @@ func TestStatic_Options(t *testing.T) {
 		))
 
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodHead, "/.editorconfig", nil)
+		req, err := http.NewRequest(http.MethodHead, "/.editorconfig", http.NoBody)
 		assert.Nil(t, err)
 
 		f.ServeHTTP(resp, req)


### PR DESCRIPTION
### Describe the pull request

This PR adds a Cache-Control option for static files that works in the same fashion as the existing Expires option.

Link to the issue:  n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
