### PR TITLE
ci: run Go tests with `-shuffle=on`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with coverage
-        run: go test -v -race -coverprofile=coverage -covermode=atomic ./...
+        run: go test -shuffle=on -v -race -coverprofile=coverage -covermode=atomic ./...
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:


### PR DESCRIPTION
Updates CI to run Go tests with `-shuffle=on`

[_Created by Sourcegraph batch change `unknwon/run-go-tests-with-shuffle`._](https://cs.unknwon.dev/users/unknwon/batch-changes/run-go-tests-with-shuffle)