### PR TITLE
static: only strip if the file path is not a single slash

### DIFF
--- a/static.go
+++ b/static.go
@@ -97,8 +97,10 @@ func Static(opts ...StaticOptions) Handler {
 			}
 		}
 
-		// The go embed file system returns an error when the path ends with a slash.
-		file = strings.TrimRight(file, "/")
+		// The go embed file system returns an error when the path ends with a slash or the path is empty.
+		if file != "/" {
+			file = strings.TrimRight(file, "/")
+		}
 
 		f, err := opt.FileSystem.Open(file)
 		if err != nil {

--- a/static.go
+++ b/static.go
@@ -98,7 +98,9 @@ func Static(opts ...StaticOptions) Handler {
 		}
 
 		// The go embed file system returns an error when the path ends with a slash or the path is empty.
-		if file != "/" {
+		if file == "/" {
+			file = "."
+		} else {
 			file = strings.TrimRight(file, "/")
 		}
 

--- a/static_test.go
+++ b/static_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//go:embed internal
+//go:embed internal README.md
 var embedFS embed.FS
 
 func TestStatic(t *testing.T) {
@@ -139,6 +139,11 @@ func TestStatic_Options(t *testing.T) {
 			},
 			{
 				uri:            "/embed/internal/route/",
+				index:          "README.md",
+				wantStatusCode: http.StatusOK,
+			},
+			{
+				uri:            "/embed/",
 				index:          "README.md",
 				wantStatusCode: http.StatusOK,
 			},


### PR DESCRIPTION
### Describe the pull request

I apologize for my carelessness. This PR is related to fixing the previous one. https://github.com/flamego/flamego/pull/170

When the `Index` file is placed in the root path of the go embed file system, the single slash `/` will be trimmed to an empty string. The go embed file system also can not accept it.  😂

I have fixed it in this PR and added the test case.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
