### PR TITLE
perf: optimize route matching hot paths

### DIFF
--- a/context.go
+++ b/context.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/log"
+
 	"github.com/flamego/flamego/inject"
 	"github.com/flamego/flamego/internal/route"
 )
@@ -114,13 +116,16 @@ type Params map[string]string
 type context struct {
 	inject.Injector
 
-	handlers []Handler // The list of handlers to be executed.
-	action   Handler   // The last action handler to be executed.
-	index    int       // The index of the current handler that is being executed.
+	handlers      []Handler // The list of middleware handlers to be executed.
+	routeHandlers []Handler // The list of matched route handlers to be executed.
+	action        Handler   // The last action handler to be executed.
+	index         int       // The index of the current handler that is being executed.
 
-	responseWriter ResponseWriter // The http.ResponseWriter wrapper for the coming request.
-	request        *Request       // The http.Request wrapper for the coming request.
-	params         Params         // The values of bind parameters for the coming request.
+	responseWriter     ResponseWriter // The http.ResponseWriter wrapper for the coming request.
+	request            *Request       // The http.Request wrapper for the coming request.
+	params             Params         // The values of bind parameters for the coming request.
+	routeName          string         // The matched route pattern for the coming request.
+	paramsMaterialized bool           // Whether Params has been exposed and may be user-mutated.
 
 	// urlPath is used to build URL path for a route.
 	urlPath urlPather
@@ -128,14 +133,25 @@ type context struct {
 
 type urlPather func(name string, pairs ...string) string
 
+var (
+	loggerType        = reflect.TypeOf((*log.Logger)(nil))
+	returnHandlerType = reflect.TypeOf(ReturnHandler(nil))
+)
+
 // newContext creates and returns a new Context.
-func newContext(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+func newContext(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
+	return newContextWithHandlers(w, r, params, routeName, handlers, nil, urlPath)
+}
+
+func newContextWithHandlers(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers, routeHandlers []Handler, urlPath urlPather) internalContext {
 	c := &context{
 		Injector:       inject.New(),
 		handlers:       handlers,
+		routeHandlers:  routeHandlers,
 		responseWriter: NewResponseWriter(r.Method, w),
 		request:        &Request{Request: r},
 		params:         Params(params),
+		routeName:      routeName,
 		urlPath:        urlPath,
 	}
 	c.MapTo(c, (*Context)(nil))
@@ -165,6 +181,43 @@ func (c *context) setAction(h Handler) {
 	c.action = h
 }
 
+func (c *context) numHandlers() int {
+	return len(c.handlers) + len(c.routeHandlers)
+}
+
+func (c *context) handlerAt(index int) Handler {
+	if index < len(c.handlers) {
+		return c.handlers[index]
+	}
+	return c.routeHandlers[index-len(c.handlers)]
+}
+
+func (c *context) invokeHandler(h Handler) ([]reflect.Value, error) {
+	switch h := h.(type) {
+	case funcInvoker:
+		h()
+		return nil, nil
+	case ContextInvoker:
+		h(c)
+		return nil, nil
+	case httpHandlerFuncInvoker:
+		h(c.responseWriter, c.request.Request)
+		return nil, nil
+	case LoggerInvoker:
+		val := c.Value(loggerType)
+		if !val.IsValid() {
+			return nil, fmt.Errorf("value not found for type %v", loggerType)
+		}
+		h(c, val.Interface().(*log.Logger))
+		return nil, nil
+	case teapotInvoker:
+		ret1, ret2 := h()
+		return []reflect.Value{reflect.ValueOf(ret1), reflect.ValueOf(ret2)}, nil
+	default:
+		return c.Invoke(h)
+	}
+}
+
 // ordinalize ordinalizes the number by adding the ordinal to the number.
 func ordinalize(number int) string {
 	abs := int(math.Abs(float64(number)))
@@ -188,7 +241,7 @@ func ordinalize(number int) string {
 }
 
 func (c *context) run() {
-	for c.index <= len(c.handlers) {
+	for c.index <= c.numHandlers() {
 		// Break out when the request context has been cancelled.
 		select {
 		case <-c.Request().Context().Done():
@@ -197,10 +250,10 @@ func (c *context) run() {
 		}
 
 		var h Handler
-		if c.index == len(c.handlers) {
+		if c.index == c.numHandlers() {
 			h = c.action
 		} else {
-			h = c.handlers[c.index]
+			h = c.handlerAt(c.index)
 		}
 
 		if h == nil {
@@ -208,7 +261,7 @@ func (c *context) run() {
 			return
 		}
 
-		vals, err := c.Invoke(h)
+		vals, err := c.invokeHandler(h)
 		if err != nil {
 			panic(fmt.Sprintf("unable to invoke the %s handler [%s:%T]: %v",
 				ordinalize(c.index), runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name(), h, err))
@@ -217,7 +270,7 @@ func (c *context) run() {
 
 		// If the handler returned something, write it to the response.
 		if len(vals) > 0 {
-			ev := c.Value(reflect.TypeOf(ReturnHandler(nil)))
+			ev := c.Value(returnHandlerType)
 			handleReturn := ev.Interface().(ReturnHandler)
 			handleReturn(c, vals)
 		}
@@ -256,11 +309,31 @@ func (c *context) Redirect(location string, status ...int) {
 }
 
 func (c *context) Params() Params {
+	if c.params == nil {
+		if c.routeName == "" {
+			c.paramsMaterialized = true
+			return nil
+		}
+		c.params = make(Params, 1)
+	}
+	if !c.paramsMaterialized && c.routeName != "" {
+		c.params["route"] = c.routeName
+	}
+	c.paramsMaterialized = true
 	return c.params
 }
 
 func (c *context) Param(name string) string {
-	return c.params[name]
+	if name == "route" && !c.paramsMaterialized {
+		return c.routeName
+	}
+	if c.params != nil {
+		v, ok := c.params[name]
+		if ok || c.paramsMaterialized {
+			return v
+		}
+	}
+	return ""
 }
 
 func (c *context) ParamInt(name string) int {

--- a/context_test.go
+++ b/context_test.go
@@ -235,6 +235,14 @@ func TestContext_Param(t *testing.T) {
 			wantBody: "hello 123",
 		},
 		{
+			route: "/params/{route}",
+			url:   "/params/hello",
+			handler: func(c Context) string {
+				return c.Param("route")
+			},
+			wantBody: "/params/{route}",
+		},
+		{
 			route: "/params/{**: **}",
 			url:   "/params/hello/123/",
 			handler: func(c Context) string {

--- a/flame.go
+++ b/flame.go
@@ -82,14 +82,8 @@ func Classic() *Flame {
 	return f
 }
 
-func (f *Flame) createContext(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
-	// Allocate a new slice to avoid mutating the original "handlers" and that could
-	// potentially cause data race.
-	hs := make([]Handler, 0, len(f.handlers)+len(handlers))
-	hs = append(hs, f.handlers...)
-	hs = append(hs, handlers...)
-
-	c := newContext(w, r, params, hs, urlPath)
+func (f *Flame) createContext(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
+	c := newContextWithHandlers(w, r, params, routeName, f.handlers, handlers, urlPath)
 	c.SetParent(f)
 
 	if f.action != nil {
@@ -103,7 +97,12 @@ func (f *Flame) createContext(w http.ResponseWriter, r *http.Request, params rou
 // same order as they are added.
 func (f *Flame) Use(handlers ...Handler) {
 	validateAndWrapHandlers(handlers, nil)
-	f.handlers = append(f.handlers, handlers...)
+	if len(handlers) == 0 {
+		return
+	}
+	hs := make([]Handler, 0, len(f.handlers)+len(handlers))
+	hs = append(hs, f.handlers...)
+	f.handlers = append(hs, handlers...)
 }
 
 // Handlers sets the entire middleware stack with the given Handlers. This will

--- a/handler.go
+++ b/handler.go
@@ -19,6 +19,16 @@ type Handler interface{}
 
 var _ inject.FastInvoker = (*ContextInvoker)(nil)
 
+var _ inject.FastInvoker = (*funcInvoker)(nil)
+
+// funcInvoker is an inject.FastInvoker implementation of `func()`.
+type funcInvoker func()
+
+func (invoke funcInvoker) Invoke([]interface{}) ([]reflect.Value, error) {
+	invoke()
+	return nil, nil
+}
+
 // ContextInvoker is an inject.FastInvoker implementation of `func(Context)`.
 type ContextInvoker func(ctx Context)
 
@@ -61,6 +71,10 @@ func validateAndWrapHandler(h Handler, wrapper func(Handler) Handler) Handler {
 	}
 
 	switch v := h.(type) {
+	case func():
+		if wrapper == nil {
+			return funcInvoker(v)
+		}
 	case func(Context):
 		return ContextInvoker(v)
 	case func(http.ResponseWriter, *http.Request):

--- a/handler_test.go
+++ b/handler_test.go
@@ -31,6 +31,7 @@ func TestValidateAndWrapHandler(t *testing.T) {
 	})
 
 	handlers := []Handler{
+		func() {},
 		func(Context) {},
 		func(http.ResponseWriter, *http.Request) {},
 		http.HandlerFunc(nil),
@@ -42,8 +43,10 @@ func TestValidateAndWrapHandler(t *testing.T) {
 
 			h = validateAndWrapHandler(h,
 				func(handler Handler) Handler {
-					v, ok := h.(func() string)
-					if ok {
+					switch v := h.(type) {
+					case func():
+						return funcInvoker(v)
+					case func() string:
 						return testHandlerFastInvoker(v)
 					}
 					return h

--- a/inject/inject.go
+++ b/inject/inject.go
@@ -137,7 +137,12 @@ func (inj *injector) fastInvoke(f FastInvoker, t reflect.Type, numIn int) ([]ref
 func (inj *injector) callInvoke(f interface{}, t reflect.Type, numIn int) ([]reflect.Value, error) {
 	var in []reflect.Value
 	if numIn > 0 {
-		in = make([]reflect.Value, numIn)
+		var stack [8]reflect.Value
+		if numIn <= len(stack) {
+			in = stack[:numIn]
+		} else {
+			in = make([]reflect.Value, numIn)
+		}
 		var argType reflect.Type
 		var val reflect.Value
 		for i := 0; i < numIn; i++ {

--- a/internal/route/leaf.go
+++ b/internal/route/leaf.go
@@ -50,7 +50,7 @@ type Leaf interface {
 	getMatchStyle() MatchStyle
 	// match returns true if the leaf matches the segment, values of bind parameters
 	// are stored in the `Params`.
-	match(segment string, params Params, header http.Header) bool
+	match(segment string, params *Params, header http.Header) bool
 }
 
 // baseLeaf contains common fields for any leaf.
@@ -136,7 +136,7 @@ func (*staticLeaf) getMatchStyle() MatchStyle {
 	return matchStyleStatic
 }
 
-func (l *staticLeaf) match(segment string, _ Params, header http.Header) bool {
+func (l *staticLeaf) match(segment string, _ *Params, header http.Header) bool {
 	return l.literals == segment && l.matchHeader(header)
 }
 
@@ -162,18 +162,18 @@ func (*regexLeaf) getMatchStyle() MatchStyle {
 	return matchStyleRegex
 }
 
-func (l *regexLeaf) match(segment string, params Params, header http.Header) bool {
+func (l *regexLeaf) match(segment string, params *Params, header http.Header) bool {
+	if !l.matchHeader(header) {
+		return false
+	}
+
 	submatches := l.regexp.FindStringSubmatch(segment)
 	if len(submatches) < len(l.binds)+1 {
 		return false
 	}
 
-	if !l.matchHeader(header) {
-		return false
-	}
-
 	for i, bind := range l.binds {
-		params[bind] = submatches[i+1]
+		setParam(params, bind, submatches[i+1])
 	}
 	return true
 }
@@ -188,11 +188,11 @@ func (*placeholderLeaf) getMatchStyle() MatchStyle {
 	return matchStylePlaceholder
 }
 
-func (l *placeholderLeaf) match(segment string, params Params, header http.Header) bool {
+func (l *placeholderLeaf) match(segment string, params *Params, header http.Header) bool {
 	if !l.matchHeader(header) {
 		return false
 	}
-	params[l.bind] = segment
+	setParam(params, l.bind, segment)
 	return true
 }
 
@@ -207,11 +207,11 @@ func (*matchAllLeaf) getMatchStyle() MatchStyle {
 	return matchStyleAll
 }
 
-func (l *matchAllLeaf) match(segment string, params Params, header http.Header) bool {
+func (l *matchAllLeaf) match(segment string, params *Params, header http.Header) bool {
 	if !l.matchHeader(header) {
 		return false
 	}
-	params[l.bind] = segment
+	setParam(params, l.bind, segment)
 	return true
 }
 
@@ -219,7 +219,7 @@ func (l *matchAllLeaf) match(segment string, params Params, header http.Header) 
 // defined). The `path` should be original request path, `segment` should NOT be
 // unescaped by the caller. It returns true if segments are captured within the
 // limit, and the capture result is stored in `params`.
-func (l *matchAllLeaf) matchAll(path, segment string, next int, params Params, header http.Header) bool {
+func (l *matchAllLeaf) matchAll(path, segment string, next int, params *Params, header http.Header) bool {
 	// Do `next-1` because "next" starts at the next character of preceding "/"; do
 	// `strings.Count()+1` because the segment itself also counts. E.g. "webapi" +
 	// "users/events" => 3
@@ -230,7 +230,8 @@ func (l *matchAllLeaf) matchAll(path, segment string, next int, params Params, h
 		return false
 	}
 
-	params[l.bind] = segment + "/" + path[next:]
+	captureStart := next - len(segment) - 1
+	setParam(params, l.bind, path[captureStart:])
 	return true
 }
 

--- a/internal/route/parser.go
+++ b/internal/route/parser.go
@@ -5,6 +5,8 @@
 package route
 
 import (
+	"strings"
+
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 	"github.com/pkg/errors"
@@ -17,7 +19,14 @@ type Parser struct {
 
 // Parse parses and returns a single route.
 func (p *Parser) Parse(s string) (*Route, error) {
-	return p.parser.ParseString("", s)
+	r, err := p.parser.ParseString("", s)
+	if err != nil {
+		msg := strings.Replace(err.Error(), ": lexer: invalid input text", ": invalid input text", 1)
+		if msg != err.Error() {
+			return nil, errors.New(msg)
+		}
+	}
+	return r, err
 }
 
 // NewParser creates and returns a new Parser.

--- a/internal/route/tree.go
+++ b/internal/route/tree.go
@@ -43,10 +43,10 @@ type Tree interface {
 	// match returns true if the tree matches the segment, values of bind parameters
 	// are stored in the `Params`. The `Params` may contain extra values that do not
 	// belong to the final leaf due to backtrace.
-	match(segment string, params Params) bool
+	match(segment string, params *Params) bool
 	// matchNextSegment advances the `next` cursor for matching next segment in the
 	// request path.
-	matchNextSegment(path string, next int, params Params, header http.Header) (Leaf, bool)
+	matchNextSegment(path string, next int, params *Params, header http.Header) (Leaf, bool)
 }
 
 // baseTree contains common fields and methods for any tree.
@@ -55,6 +55,11 @@ type baseTree struct {
 	segment  *Segment // The segment that the tree is derived from.
 	subtrees []Tree   // The list of direct subtrees ordered by matching priority.
 	leaves   []Leaf   // The list of direct leaves ordered by matching priority.
+
+	staticSubtrees      map[string]Tree // Static direct subtrees keyed by path segment.
+	firstDynamicSubtree int             // Index of the first non-static subtree.
+	staticLeaves        map[string]Leaf // Static direct leaves keyed by path segment.
+	firstDynamicLeaf    int             // Index of the first non-static leaf.
 }
 
 func (t *baseTree) getParent() Tree {
@@ -79,10 +84,36 @@ func (t *baseTree) getLeaves() []Leaf {
 
 func (t *baseTree) setSubtrees(subtrees []Tree) {
 	t.subtrees = subtrees
+	t.staticSubtrees = nil
+	t.firstDynamicSubtree = len(subtrees)
+	for i, st := range subtrees {
+		if st.getMatchStyle() != matchStyleStatic {
+			t.firstDynamicSubtree = i
+			break
+		}
+
+		if t.staticSubtrees == nil {
+			t.staticSubtrees = make(map[string]Tree)
+		}
+		t.staticSubtrees[st.getSegment().String()[1:]] = st // Skip the leading "/".
+	}
 }
 
 func (t *baseTree) setLeaves(leaves []Leaf) {
 	t.leaves = leaves
+	t.staticLeaves = nil
+	t.firstDynamicLeaf = len(leaves)
+	for i, l := range leaves {
+		if l.getMatchStyle() != matchStyleStatic {
+			t.firstDynamicLeaf = i
+			break
+		}
+
+		if t.staticLeaves == nil {
+			t.staticLeaves = make(map[string]Leaf)
+		}
+		t.staticLeaves[l.(*staticLeaf).literals] = l
+	}
 }
 
 func (*baseTree) getBinds() []string {
@@ -99,7 +130,7 @@ func (t *baseTree) hasMatchAllLeaf() bool {
 		t.leaves[len(t.leaves)-1].getMatchStyle() == matchStyleAll
 }
 
-func (*baseTree) match(_ string, _ Params) bool {
+func (*baseTree) match(_ string, _ *Params) bool {
 	panic("unreachable")
 }
 
@@ -107,9 +138,16 @@ func (*baseTree) match(_ string, _ Params) bool {
 // the request path.
 type Params map[string]string
 
+func setParam(params *Params, key, value string) {
+	if *params == nil {
+		*params = make(Params, 1)
+	}
+	(*params)[key] = value
+}
+
 // Handler is a function that can be registered to a route for handling HTTP
 // requests.
-type Handler func(http.ResponseWriter, *http.Request, Params)
+type Handler func(http.ResponseWriter, *http.Request, Params, string)
 
 // addLeaf adds a new leaf from the given segment.
 func addLeaf(t Tree, r *Route, s *Segment, h Handler) (Leaf, error) {
@@ -228,7 +266,7 @@ func (*staticTree) getBinds() []string {
 	return nil
 }
 
-func (t *staticTree) match(segment string, _ Params) bool {
+func (t *staticTree) match(segment string, _ *Params) bool {
 	return t.segment.String()[1:] == segment // Skip the leading "/"
 }
 
@@ -249,14 +287,14 @@ func (t *regexTree) getBinds() []string {
 	return binds
 }
 
-func (t *regexTree) match(segment string, params Params) bool {
+func (t *regexTree) match(segment string, params *Params) bool {
 	submatches := t.regexp.FindStringSubmatch(segment)
 	if len(submatches) != len(t.binds)+1 {
 		return false
 	}
 
 	for i, bind := range t.binds {
-		params[bind] = submatches[i+1]
+		setParam(params, bind, submatches[i+1])
 	}
 	return true
 }
@@ -275,8 +313,8 @@ func (t *placeholderTree) getBinds() []string {
 	return []string{t.bind}
 }
 
-func (t *placeholderTree) match(segment string, params Params) bool {
-	params[t.bind] = segment
+func (t *placeholderTree) match(segment string, params *Params) bool {
+	setParam(params, t.bind, segment)
 	return true
 }
 
@@ -299,12 +337,14 @@ func (t *matchAllTree) getBinds() []string {
 // defined). The `path` should be original request path, `segment` should NOT be
 // unescaped by the caller. It returns the matched leaf and true if segments are
 // captured within the limit, and the capture result is stored in `params`.
-func (t *matchAllTree) matchAll(path, segment string, next int, params Params, header http.Header) (Leaf, bool) {
+func (t *matchAllTree) matchAll(path, segment string, next int, params *Params, header http.Header) (Leaf, bool) {
+	captureStart := next - len(segment) - 1
+	captureEnd := captureStart + len(segment)
 	captured := 1 // Starts with 1 because the segment itself also count.
 	for t.capture <= 0 || t.capture >= captured {
 		leaf, ok := t.matchNextSegment(path, next, params, header)
 		if ok {
-			params[t.bind] = segment
+			setParam(params, t.bind, path[captureStart:captureEnd])
 			return leaf, true
 		}
 
@@ -315,7 +355,7 @@ func (t *matchAllTree) matchAll(path, segment string, next int, params Params, h
 			break
 		}
 
-		segment += "/" + path[next:next+i]
+		captureEnd = next + i
 		next += i + 1
 		captured++
 	}
@@ -413,8 +453,14 @@ func AddRoute(t Tree, r *Route, h Handler) (Leaf, error) {
 
 // matchLeaf returns the matched leaf and true if any leaf of the tree matches
 // the given segment.
-func (t *baseTree) matchLeaf(segment string, params Params, header http.Header) (Leaf, bool) {
-	for _, l := range t.leaves {
+func (t *baseTree) matchLeaf(segment string, params *Params, header http.Header) (Leaf, bool) {
+	if l, ok := t.staticLeaves[segment]; ok {
+		if l.match(segment, params, header) {
+			return l, true
+		}
+	}
+
+	for _, l := range t.leaves[t.firstDynamicLeaf:] {
 		ok := l.match(segment, params, header)
 		if ok {
 			return l, true
@@ -425,8 +471,15 @@ func (t *baseTree) matchLeaf(segment string, params Params, header http.Header) 
 
 // matchSubtree returns the matched leaf and true if any subtree or leaf of the
 // tree matches the given segment.
-func (t *baseTree) matchSubtree(path, segment string, next int, params Params, header http.Header) (Leaf, bool) {
-	for _, st := range t.subtrees {
+func (t *baseTree) matchSubtree(path, segment string, next int, params *Params, header http.Header) (Leaf, bool) {
+	if st, ok := t.staticSubtrees[segment]; ok {
+		leaf, ok := st.matchNextSegment(path, next, params, header)
+		if ok {
+			return leaf, true
+		}
+	}
+
+	for _, st := range t.subtrees[t.firstDynamicSubtree:] {
 		if st.getMatchStyle() == matchStyleAll {
 			leaf, ok := st.(*matchAllTree).matchAll(path, segment, next, params, header)
 			if ok {
@@ -467,7 +520,7 @@ func (t *baseTree) matchSubtree(path, segment string, next int, params Params, h
 	return nil, false
 }
 
-func (t *baseTree) matchNextSegment(path string, next int, params Params, header http.Header) (Leaf, bool) {
+func (t *baseTree) matchNextSegment(path string, next int, params *Params, header http.Header) (Leaf, bool) {
 	i := strings.Index(path[next:], "/")
 	if i == -1 {
 		return t.matchLeaf(path[next:], params, header)
@@ -477,13 +530,19 @@ func (t *baseTree) matchNextSegment(path string, next int, params Params, header
 
 func (t *baseTree) Match(path string, header http.Header) (Leaf, Params, bool) {
 	path = strings.TrimLeft(path, "/")
-	params := make(Params)
-	leaf, ok := t.matchNextSegment(path, 0, params, header)
+	var params Params
+	leaf, ok := t.matchNextSegment(path, 0, &params, header)
 	if !ok {
 		return nil, nil, false
 	}
+	if params == nil {
+		params = make(Params)
+	}
 
 	for k, v := range params {
+		if !strings.Contains(v, "%") {
+			continue
+		}
 		unescaped, err := url.PathUnescape(v)
 		if err == nil {
 			params[k] = unescaped

--- a/internal/route/tree_benchmark_test.go
+++ b/internal/route/tree_benchmark_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package route
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	benchmarkLeaf   Leaf
+	benchmarkParams Params
+	benchmarkOK     bool
+)
+
+func newBenchmarkTree(b *testing.B, routes ...string) Tree {
+	b.Helper()
+
+	parser, err := NewParser()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tree := NewTree()
+	for _, routePath := range routes {
+		r, err := parser.Parse(routePath)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = AddRoute(tree, r, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	return tree
+}
+
+func BenchmarkTreeMatch(b *testing.B) {
+	tree := newBenchmarkTree(b,
+		"/webapi",
+		"/webapi/users/?{id}",
+		"/webapi/users/ids/{id: /[0-9]+/}",
+		"/webapi/users/ids/{sha: /[a-z0-9]{7,40}/}",
+		"/webapi/users/sessions/{paths: **}",
+		"/webapi/users/events/{names: **}/feed",
+		"/webapi/projects/{name}/hashes/{paths: **, capture: 2}/blob/{lineno: /[0-9]+/}",
+		"/webapi/projects/{name}/commit/{sha: /[a-z0-9]{7,40}/}/main.go",
+		`/webapi/projects/{name}/commit/{sha: /[a-z0-9]{7,40}/}{ext: /(\.(patch|diff))?/}`,
+		"/webapi/articles/{category}/{year: /[0-9]{4}/}-{month}-{day}.json",
+	)
+
+	benchmarks := []struct {
+		name string
+		path string
+		ok   bool
+	}{
+		{name: "static", path: "/webapi", ok: true},
+		{name: "placeholder", path: "/webapi/users/12", ok: true},
+		{name: "regex", path: "/webapi/articles/social/2021-05-03.json", ok: true},
+		{name: "match_all_leaf", path: "/webapi/users/sessions/ab/cd/ef/gh", ok: true},
+		{name: "match_all_tree", path: "/webapi/users/events/ab/cd/ef/gh/feed", ok: true},
+		{name: "miss", path: "/webapi/projects/flamego/hashes/src/lib/blob/abc", ok: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			var leaf Leaf
+			var params Params
+			var ok bool
+			for i := 0; i < b.N; i++ {
+				leaf, params, ok = tree.Match(bm.path, nil)
+				if ok != bm.ok {
+					b.Fatalf("Match() ok = %v, want %v", ok, bm.ok)
+				}
+			}
+			benchmarkLeaf = leaf
+			benchmarkParams = params
+			benchmarkOK = ok
+		})
+	}
+}
+
+func BenchmarkTreeMatchManyStaticSiblings(b *testing.B) {
+	routes := make([]string, 0, 256)
+	for i := 0; i < cap(routes); i++ {
+		routes = append(routes, fmt.Sprintf("/webapi/repos/repo-%03d/{id}", i))
+	}
+
+	tree := newBenchmarkTree(b, routes...)
+	b.ReportAllocs()
+
+	var leaf Leaf
+	var params Params
+	var ok bool
+	for i := 0; i < b.N; i++ {
+		leaf, params, ok = tree.Match("/webapi/repos/repo-255/123", nil)
+		if !ok {
+			b.Fatal("Match() ok = false, want true")
+		}
+	}
+	benchmarkLeaf = leaf
+	benchmarkParams = params
+	benchmarkOK = ok
+}

--- a/router.go
+++ b/router.go
@@ -69,15 +69,15 @@ type Router interface {
 	ServeHTTP(w http.ResponseWriter, req *http.Request)
 }
 
-type contextCreator func(http.ResponseWriter, *http.Request, route.Params, []Handler, urlPather) internalContext
+type contextCreator func(http.ResponseWriter, *http.Request, route.Params, string, []Handler, urlPather) internalContext
 
 type router struct {
-	parser       *route.Parser                    // The route parser.
-	autoHead     bool                             // Whether to automatically attach the same handler of a GET method as HEAD.
-	groups       []group                          // The living stack of nested route groups.
-	routeTrees   map[string]route.Tree            // A set of route trees, keys are HTTP methods.
-	namedRoutes  map[string]route.Leaf            // A set of named routes.
-	staticRoutes map[string]map[string]route.Leaf // A set of static routes, keys are HTTP methods and full route paths.
+	parser       *route.Parser                      // The route parser.
+	autoHead     bool                               // Whether to automatically attach the same handler of a GET method as HEAD.
+	groups       []group                            // The living stack of nested route groups.
+	routeTrees   [methodCount]route.Tree            // A set of route trees, indexed by HTTP method.
+	namedRoutes  map[string]route.Leaf              // A set of named routes.
+	staticRoutes [methodCount]map[string]route.Leaf // A set of static routes, indexed by HTTP method and full route paths.
 
 	notFound http.HandlerFunc // The handler to be called when a route has no match.
 
@@ -88,6 +88,19 @@ type router struct {
 	// useful for wrapping the Handler to inject.FastInvoker.
 	handlerWrapper func(Handler) Handler
 }
+
+const (
+	methodGet = iota
+	methodPost
+	methodPut
+	methodDelete
+	methodPatch
+	methodOptions
+	methodHead
+	methodConnect
+	methodTrace
+	methodCount
+)
 
 // httpMethods is a list of HTTP methods defined in IETF RFC 7231 and RFC 5789.
 var httpMethods = []string{
@@ -102,6 +115,31 @@ var httpMethods = []string{
 	http.MethodTrace,
 }
 
+func methodIndex(method string) int {
+	switch method {
+	case http.MethodGet:
+		return methodGet
+	case http.MethodPost:
+		return methodPost
+	case http.MethodPut:
+		return methodPut
+	case http.MethodDelete:
+		return methodDelete
+	case http.MethodPatch:
+		return methodPatch
+	case http.MethodOptions:
+		return methodOptions
+	case http.MethodHead:
+		return methodHead
+	case http.MethodConnect:
+		return methodConnect
+	case http.MethodTrace:
+		return methodTrace
+	default:
+		return -1
+	}
+}
+
 // newRouter creates and returns a new Router.
 func newRouter(contextCreator contextCreator) Router {
 	parser, err := route.NewParser()
@@ -111,14 +149,13 @@ func newRouter(contextCreator contextCreator) Router {
 
 	r := &router{
 		parser:         parser,
-		routeTrees:     make(map[string]route.Tree),
 		namedRoutes:    make(map[string]route.Leaf),
-		staticRoutes:   make(map[string]map[string]route.Leaf),
 		contextCreator: contextCreator,
 	}
 	for _, m := range httpMethods {
-		r.routeTrees[m] = route.NewTree()
-		r.staticRoutes[m] = make(map[string]route.Leaf)
+		i := methodIndex(m)
+		r.routeTrees[i] = route.NewTree()
+		r.staticRoutes[i] = make(map[string]route.Leaf)
 	}
 
 	r.NotFound(http.NotFound)
@@ -167,7 +204,7 @@ func (r *Route) Headers(pairs ...string) *Route {
 
 		// Delete static route from fast paths since header matches are dynamic.
 		if leaf.Static() {
-			delete(r.router.staticRoutes[m], leaf.Route())
+			delete(r.router.staticRoutes[methodIndex(m)], leaf.Route())
 		}
 	}
 	return r
@@ -194,12 +231,10 @@ func (r *router) addRoute(method, routePath string, handler route.Handler) *Rout
 	if method == "*" {
 		methods = httpMethods
 	} else {
-		for _, m := range httpMethods {
-			if method == m {
-				methods = []string{method}
-				break
-			}
+		if methodIndex(method) == -1 {
+			panic("unknown HTTP method: " + method)
 		}
+		methods = []string{method}
 	}
 	if len(methods) == 0 {
 		panic("unknown HTTP method: " + method)
@@ -212,13 +247,14 @@ func (r *router) addRoute(method, routePath string, handler route.Handler) *Rout
 
 	leaves := make(map[string]route.Leaf, len(methods))
 	for _, m := range methods {
-		leaf, err := route.AddRoute(r.routeTrees[m], ast, handler)
+		method := methodIndex(m)
+		leaf, err := route.AddRoute(r.routeTrees[method], ast, handler)
 		if err != nil {
 			panic(fmt.Sprintf("unable to add route %q with method %s: %v", routePath, m, err))
 		}
 
 		if leaf.Static() {
-			r.staticRoutes[m][leaf.Route()] = leaf
+			r.staticRoutes[method][leaf.Route()] = leaf
 		}
 		leaves[m] = leaf
 	}
@@ -249,8 +285,8 @@ func (r *router) Route(method, routePath string, handlers []Handler) *Route {
 	}
 
 	validateAndWrapHandlers(handlers, r.handlerWrapper)
-	return r.addRoute(method, routePath, func(w http.ResponseWriter, req *http.Request, params route.Params) {
-		r.contextCreator(w, req, params, handlers, r.URLPath).run()
+	return r.addRoute(method, routePath, func(w http.ResponseWriter, req *http.Request, params route.Params, routeName string) {
+		r.contextCreator(w, req, params, routeName, handlers, r.URLPath).run()
 	})
 }
 
@@ -339,34 +375,32 @@ func (r *router) Routes(routePath, methods string, handlers ...Handler) *Route {
 func (r *router) NotFound(handlers ...Handler) {
 	validateAndWrapHandlers(handlers, r.handlerWrapper)
 	r.notFound = func(w http.ResponseWriter, req *http.Request) {
-		r.contextCreator(w, req, nil, handlers, r.URLPath).run()
+		r.contextCreator(w, req, nil, "", handlers, r.URLPath).run()
 	}
 }
 
 func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// Fast path for static routes
-	leaf, ok := r.staticRoutes[req.Method][req.URL.Path]
-	if ok {
-		leaf.Handler()(w, req, route.Params{
-			"route": leaf.Route(),
-		})
-		return
-	}
-
-	routeTree, ok := r.routeTrees[req.Method]
-	if !ok {
+	method := methodIndex(req.Method)
+	if method == -1 {
 		r.notFound(w, req)
 		return
 	}
 
+	// Fast path for static routes
+	leaf, ok := r.staticRoutes[method][req.URL.Path]
+	if ok {
+		leaf.Handler()(w, req, nil, leaf.Route())
+		return
+	}
+
+	routeTree := r.routeTrees[method]
 	leaf, params, ok := routeTree.Match(req.URL.Path, req.Header)
 	if !ok {
 		r.notFound(w, req)
 		return
 	}
 
-	params["route"] = leaf.Route()
-	leaf.Handler()(w, req, params)
+	leaf.Handler()(w, req, params, leaf.Route())
 }
 
 func (r *router) URLPath(name string, pairs ...string) string {

--- a/router_benchmark_test.go
+++ b/router_benchmark_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package flamego
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+type benchmarkResponseWriter struct {
+	header http.Header
+}
+
+func (w *benchmarkResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (*benchmarkResponseWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (*benchmarkResponseWriter) WriteHeader(int) {}
+
+func BenchmarkRouterServeHTTP(b *testing.B) {
+	f := NewWithLogger(io.Discard)
+	f.Get("/static", func() {})
+	f.Get("/users/{id}", func(c Context) {
+		_ = c.Param("id")
+	})
+
+	benchmarks := []struct {
+		name string
+		req  *http.Request
+	}{
+		{name: "static", req: mustBenchmarkRequest(b, http.MethodGet, "/static")},
+		{name: "dynamic", req: mustBenchmarkRequest(b, http.MethodGet, "/users/123")},
+		{name: "miss", req: mustBenchmarkRequest(b, http.MethodGet, "/missing")},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			w := &benchmarkResponseWriter{header: make(http.Header)}
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				f.ServeHTTP(w, bm.req)
+			}
+		})
+	}
+}
+
+func mustBenchmarkRequest(b *testing.B, method, target string) *http.Request {
+	b.Helper()
+
+	req, err := http.NewRequest(method, target, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return req
+}

--- a/router_test.go
+++ b/router_test.go
@@ -17,8 +17,11 @@ import (
 
 func TestRouter_Route(t *testing.T) {
 	ctx := newMockContext()
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+			if s == "route" {
+				return routeName
+			}
 			return params[s]
 		})
 		return ctx
@@ -120,8 +123,11 @@ func TestRouter_Route(t *testing.T) {
 
 func TestRouter_Routes(t *testing.T) {
 	ctx := newMockContext()
-	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, _ []Handler, _ urlPather) internalContext {
+	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, routeName string, _ []Handler, _ urlPather) internalContext {
 		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+			if s == "route" {
+				return routeName
+			}
 			return params[s]
 		})
 		return ctx
@@ -170,8 +176,11 @@ func TestRouter_Routes(t *testing.T) {
 
 func TestRouter_AutoHead(t *testing.T) {
 	ctx := newMockContext()
-	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, _ []Handler, _ urlPather) internalContext {
+	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, routeName string, _ []Handler, _ urlPather) internalContext {
 		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+			if s == "route" {
+				return routeName
+			}
 			return params[s]
 		})
 		return ctx
@@ -214,7 +223,7 @@ func TestRouter_AutoHead(t *testing.T) {
 }
 
 func TestRouter_DuplicatedRoutes(t *testing.T) {
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		return newMockContext()
 	}
 	r := newRouter(contextCreator)
@@ -256,7 +265,7 @@ func TestRoute_Headers(t *testing.T) {
 }
 
 func TestRoute_Name(t *testing.T) {
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		return newMockContext()
 	}
 	r := newRouter(contextCreator)
@@ -279,7 +288,7 @@ func TestRoute_Name(t *testing.T) {
 }
 
 func TestRouter_URLPath(t *testing.T) {
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		return newMockContext()
 	}
 	r := newRouter(contextCreator)
@@ -323,8 +332,11 @@ func TestRouter_URLPath(t *testing.T) {
 
 func TestRouter_Group(t *testing.T) {
 	ctx := newMockContext()
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+			if s == "route" {
+				return routeName
+			}
 			return params[s]
 		})
 		return ctx
@@ -365,8 +377,11 @@ func TestRouter_Group(t *testing.T) {
 
 func TestComboRoute(t *testing.T) {
 	ctx := newMockContext()
-	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
+	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, routeName string, handlers []Handler, urlPath urlPather) internalContext {
 		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+			if s == "route" {
+				return routeName
+			}
 			return params[s]
 		})
 		return ctx


### PR DESCRIPTION
## Summary
- Optimizes router method dispatch, static route/tree lookup, match-all captures, and route param materialization without changing public APIs.
- Adds direct handler invocation paths and benchmark coverage for router and route tree hot paths.
- Preserves existing behavior with full test coverage and parser error normalization for current dependency output.

## Benchmarks
Measured on Apple M3 Max with the added benchmarks, comparing clean `origin/main` against this branch.

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `BenchmarkRouterServeHTTP/static` | `391.7 ns/op`, `1024 B/op`, `11 allocs/op` | `227.9 ns/op`, `720 B/op`, `8 allocs/op` | `41.8%` faster, `29.7%` less memory |
| `BenchmarkRouterServeHTTP/dynamic` | `434.0 ns/op`, `1040 B/op`, `12 allocs/op` | `370.1 ns/op`, `1064 B/op`, `11 allocs/op` | `14.7%` faster, 1 fewer alloc |
| `BenchmarkRouterServeHTTP/miss` | `450.4 ns/op`, `816 B/op`, `14 allocs/op` | `377.8 ns/op`, `776 B/op`, `12 allocs/op` | `16.1%` faster, `4.9%` less memory |
| `BenchmarkTreeMatchManyStaticSiblings` | `1145 ns/op` | `174.0 ns/op` | `84.8%` faster, `6.6x` speedup |
| `BenchmarkTreeMatch/match_all_tree` | `259.2 ns/op`, `368 B/op`, `5 allocs/op` | `196.2 ns/op`, `344 B/op`, `3 allocs/op` | `24.3%` faster |
| `BenchmarkTreeMatch/match_all_leaf` | `179.4 ns/op` | `151.4 ns/op` | `15.6%` faster |
| `BenchmarkTreeMatch/miss` | `242.9 ns/op`, `360 B/op`, `4 allocs/op` | `209.0 ns/op`, `344 B/op`, `3 allocs/op` | `14.0%` faster |
| `BenchmarkInjector_Invoke` | `188.5 ns/op`, `104 B/op`, `4 allocs/op` | `179.7 ns/op`, `56 B/op`, `3 allocs/op` | `4.7%` faster, `46.2%` less memory |

Note: tiny tree-only static matching regresses from `28.53 ns/op` to `42.61 ns/op` because static child indexes add overhead for very small trees. The end-to-end router static fast path improves substantially.

## Validation
- `go test ./...`