### PR TITLE
ci: bump to Go 1.26 and modernize CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
@@ -47,7 +47,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -72,4 +72,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          go-version: '1.26'
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout=30m
@@ -44,11 +44,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          go-version: '1.26'
       - name: Run tests with coverage (windows)
         if: ${{ matrix.platform == 'windows-latest' }}
         continue-on-error: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,37 @@
-linters-settings:
-  nakedret:
-    max-func-lines: 0 # Disallow any unnamed return statement
-
+version: "2"
 linters:
   enable:
-    - unused
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
     - nakedret
-    - gofmt
     - rowserrcheck
     - unconvert
-    - goimports
     - unparam
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - "-SA1019" # This project is under active refactoring and not all code is up to date.
+        - "-QF1001" # I'm a math noob
+        - "-ST1016" # Some legit code uses this pattern
+    nakedret:
+      max-func-lines: 0 # Disallow any unnamed return statement
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is the successor of the [Macaron](https://github.com/go-macaron/macaron), and
 
 ## Installation
 
-The minimum requirement of Go is **1.19**.
+The minimum requirement of Go is **1.26**.
 
 	go get github.com/flamego/flamego
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flamego/flamego
 
-go 1.19
+go 1.26
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/inject/inject.go
+++ b/inject/inject.go
@@ -83,7 +83,7 @@ type injector struct {
 // is not an pointer to an interface.
 func InterfaceOf(value interface{}) reflect.Type {
 	t := reflect.TypeOf(value)
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -156,7 +156,7 @@ func (inj *injector) callInvoke(f interface{}, t reflect.Type, numIn int) ([]ref
 func (inj *injector) Apply(val interface{}) error {
 	v := reflect.ValueOf(val)
 
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/internal/route/parser_test.go
+++ b/internal/route/parser_test.go
@@ -598,12 +598,12 @@ func TestParser(t *testing.T) {
 			{
 				name:    "missing leading slash",
 				route:   "webapi",
-				wantErr: `1:1: invalid input text "webapi"`,
+				wantErr: `1:1: lexer: invalid input text "webapi"`,
 			},
 			{
 				name:    "missing opening bracket",
 				route:   "/name}",
-				wantErr: `1:6: invalid input text "}"`,
+				wantErr: `1:6: lexer: invalid input text "}"`,
 			},
 			{
 				name:    "missing closing bracket",
@@ -613,7 +613,7 @@ func TestParser(t *testing.T) {
 			{
 				name:    "no surroundings for regex",
 				route:   "/{name: [a-z0-9]{7, 40}}",
-				wantErr: `1:9: invalid input text "[a-z0-9]{7, 40}}"`,
+				wantErr: `1:9: lexer: invalid input text "[a-z0-9]{7, 40}}"`,
 			},
 		}
 		for _, test := range tests {

--- a/return_handler.go
+++ b/return_handler.go
@@ -18,7 +18,7 @@ type ReturnHandler func(Context, []reflect.Value)
 
 func defaultReturnHandler() ReturnHandler {
 	canDeref := func(val reflect.Value) bool {
-		return val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr
+		return val.Kind() == reflect.Interface || val.Kind() == reflect.Pointer
 	}
 
 	isByteSlice := func(val reflect.Value) bool {

--- a/router_test.go
+++ b/router_test.go
@@ -18,7 +18,7 @@ import (
 func TestRouter_Route(t *testing.T) {
 	ctx := newMockContext()
 	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
-		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+		ctx.ParamFunc.SetDefaultHook(func(s string) string {
 			return params[s]
 		})
 		return ctx
@@ -121,7 +121,7 @@ func TestRouter_Route(t *testing.T) {
 func TestRouter_Routes(t *testing.T) {
 	ctx := newMockContext()
 	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, _ []Handler, _ urlPather) internalContext {
-		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+		ctx.ParamFunc.SetDefaultHook(func(s string) string {
 			return params[s]
 		})
 		return ctx
@@ -171,7 +171,7 @@ func TestRouter_Routes(t *testing.T) {
 func TestRouter_AutoHead(t *testing.T) {
 	ctx := newMockContext()
 	contextCreator := func(_ http.ResponseWriter, _ *http.Request, params route.Params, _ []Handler, _ urlPather) internalContext {
-		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+		ctx.ParamFunc.SetDefaultHook(func(s string) string {
 			return params[s]
 		})
 		return ctx
@@ -324,7 +324,7 @@ func TestRouter_URLPath(t *testing.T) {
 func TestRouter_Group(t *testing.T) {
 	ctx := newMockContext()
 	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
-		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+		ctx.ParamFunc.SetDefaultHook(func(s string) string {
 			return params[s]
 		})
 		return ctx
@@ -366,7 +366,7 @@ func TestRouter_Group(t *testing.T) {
 func TestComboRoute(t *testing.T) {
 	ctx := newMockContext()
 	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
-		ctx.MockContext.ParamFunc.SetDefaultHook(func(s string) string {
+		ctx.ParamFunc.SetDefaultHook(func(s string) string {
 			return params[s]
 		})
 		return ctx


### PR DESCRIPTION
## Summary
- Pin Go to **1.26** in workflows and `go.mod` (was 1.19); update README minimum Go version.
- Bump GitHub Actions: `actions/checkout` v4→v6, `actions/setup-go` v5→v6, `golangci/golangci-lint-action` v4→v9, `github/codeql-action` v2→v4.
- Migrate `.golangci.yml` to the v2 schema (matches the gogs/gogs config).
- Fix the small fallout this exposed:
  - `reflect.Ptr` → `reflect.Pointer` in `inject/inject.go` and `return_handler.go` (`govet inline`).
  - Drop redundant `MockContext` selector in `router_test.go` (`staticcheck QF1008`).
  - Update participle 2.1.4 lexer error prefix in `internal/route/parser_test.go` (failing tests since #185).

## Test plan
- [x] `go test -shuffle=on -race ./...` passes locally on go1.26.2
- [x] `golangci-lint run ./...` reports 0 issues (v2.12.1)
- [ ] CI lint/test matrix passes on ubuntu, macos, windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)