### PR TITLE
router: populate http.Request.Pattern with matched route

### DIFF
--- a/router.go
+++ b/router.go
@@ -347,6 +347,7 @@ func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Fast path for static routes
 	leaf, ok := r.staticRoutes[req.Method][req.URL.Path]
 	if ok {
+		req.Pattern = req.Method + " " + leaf.Route()
 		leaf.Handler()(w, req, route.Params{
 			"route": leaf.Route(),
 		})
@@ -366,6 +367,7 @@ func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	params["route"] = leaf.Route()
+	req.Pattern = req.Method + " " + leaf.Route()
 	leaf.Handler()(w, req, params)
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -139,8 +139,26 @@ func TestRouter_Route(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, resp.Code)
 			assert.Equal(t, test.routePath, gotRoute)
+			assert.Equal(t, test.method+" "+test.routePath, req.Pattern)
 		})
 	}
+
+	t.Run("dynamic route pattern", func(t *testing.T) {
+		r.Get("/users/{id}", func() {})
+
+		gotRoute := ""
+		ctx.run_ = func() { gotRoute = ctx.Param("route") }
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/users/42", nil)
+		require.NoError(t, err)
+
+		r.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, "/users/{id}", gotRoute)
+		assert.Equal(t, "GET /users/{id}", req.Pattern)
+	})
 }
 
 func TestRouter_Routes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Sets `req.Pattern` to `"METHOD /path/pattern"` on both the static fast path and the dynamic tree-match path in `router.ServeHTTP`.
- Uses the format established by Go 1.22+ `net/http.ServeMux`, where [`Request.Pattern`](https://pkg.go.dev/net/http#Request) holds the matched pattern. Letting Flamego populate the same field gives middleware (logging, metrics, tracing) a standard place to read the matched route template, no matter which router did the matching.
- The pattern string reuses `leaf.Route()` (already exposed as `c.Param("route")`), so behavior is consistent with the existing route param.

## Test plan
- [x] `go test ./...` passes
- [x] `TestRouter_Route` extended to assert `req.Pattern == "METHOD /path"` for every static method binding in the table
- [x] New `TestRouter_Route/dynamic route pattern` subtest covers the parametric tree-match branch (`GET /users/{id}` -> `"GET /users/{id}"`)