### PR TITLE
handler: accept http.Handler implementations as flamego.Handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -54,6 +54,10 @@ func (invoke teapotInvoker) Invoke([]interface{}) ([]reflect.Value, error) {
 // implementations, it wraps the handler automatically to gain up to 3x
 // performance improvement.
 func validateAndWrapHandler(h Handler, wrapper func(Handler) Handler) Handler {
+	if h == nil {
+		panic("handler must be a callable function or http.Handler, but got nil")
+	}
+
 	if inject.IsFastInvoker(h) {
 		return h
 	}

--- a/handler.go
+++ b/handler.go
@@ -12,9 +12,10 @@ import (
 	"github.com/flamego/flamego/inject"
 )
 
-// Handler is any callable function. Flamego attempts to inject services into
-// the Handler's argument list and panics if any argument could not be fulfilled
-// via dependency injection.
+// Handler is any callable function or a value that implements http.Handler.
+// Flamego attempts to inject services into the Handler's argument list and
+// panics if any argument could not be fulfilled via dependency injection.
+// Values implementing http.Handler are invoked via their ServeHTTP method.
 type Handler interface{}
 
 var _ inject.FastInvoker = (*ContextInvoker)(nil)
@@ -47,15 +48,12 @@ func (invoke teapotInvoker) Invoke([]interface{}) ([]reflect.Value, error) {
 	return []reflect.Value{reflect.ValueOf(ret1), reflect.ValueOf(ret2)}, nil
 }
 
-// validateAndWrapHandler makes sure the handler is a callable function, it
-// panics if not. When the handler is also convertible to any built-in
-// inject.FastInvoker implementations, it wraps the handler automatically to
-// gain up to 3x performance improvement.
+// validateAndWrapHandler makes sure the handler is either a callable function
+// or a value that implements http.Handler, and panics otherwise. When the
+// handler is also convertible to any built-in inject.FastInvoker
+// implementations, it wraps the handler automatically to gain up to 3x
+// performance improvement.
 func validateAndWrapHandler(h Handler, wrapper func(Handler) Handler) Handler {
-	if reflect.TypeOf(h).Kind() != reflect.Func {
-		panic(fmt.Sprintf("handler must be a callable function, but got %T", h))
-	}
-
 	if inject.IsFastInvoker(h) {
 		return h
 	}
@@ -69,6 +67,14 @@ func validateAndWrapHandler(h Handler, wrapper func(Handler) Handler) Handler {
 		return httpHandlerFuncInvoker(v)
 	case func() (int, string):
 		return teapotInvoker(v)
+	}
+
+	if hh, ok := h.(http.Handler); ok {
+		return httpHandlerFuncInvoker(hh.ServeHTTP)
+	}
+
+	if reflect.TypeOf(h).Kind() != reflect.Func {
+		panic(fmt.Sprintf("handler must be a callable function or http.Handler, but got %T", h))
 	}
 
 	if wrapper != nil {

--- a/handler_test.go
+++ b/handler_test.go
@@ -22,10 +22,14 @@ func (invoke testHandlerFastInvoker) Invoke([]interface{}) ([]reflect.Value, err
 	return []reflect.Value{reflect.ValueOf(invoke())}, nil
 }
 
+type testHTTPHandler struct{}
+
+func (testHTTPHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
 func TestValidateAndWrapHandler(t *testing.T) {
 	t.Run("not a callable function", func(t *testing.T) {
 		defer func() {
-			assert.Contains(t, recover(), "handler must be a callable function")
+			assert.Contains(t, recover(), "handler must be a callable function or http.Handler")
 		}()
 		validateAndWrapHandler("string", nil)
 	})
@@ -35,6 +39,7 @@ func TestValidateAndWrapHandler(t *testing.T) {
 		func(http.ResponseWriter, *http.Request) {},
 		http.HandlerFunc(nil),
 		func() string { return "" },
+		testHTTPHandler{},
 	}
 	for _, h := range handlers {
 		t.Run("handlers", func(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -34,6 +34,21 @@ func TestValidateAndWrapHandler(t *testing.T) {
 		validateAndWrapHandler("string", nil)
 	})
 
+	t.Run("nil handler", func(t *testing.T) {
+		defer func() {
+			assert.Contains(t, recover(), "handler must be a callable function or http.Handler")
+		}()
+		validateAndWrapHandler(nil, nil)
+	})
+
+	t.Run("nil http.Handler interface", func(t *testing.T) {
+		defer func() {
+			assert.Contains(t, recover(), "handler must be a callable function or http.Handler")
+		}()
+		var hh http.Handler
+		validateAndWrapHandler(hh, nil)
+	})
+
 	handlers := []Handler{
 		func(Context) {},
 		func(http.ResponseWriter, *http.Request) {},


### PR DESCRIPTION
### Describe the pull request

Make `flamego.Handler` automatically recognize any value implementing [`http.Handler`](https://pkg.go.dev/net/http#Handler). Such values are wrapped via the existing `httpHandlerFuncInvoker` on their `ServeHTTP` method, so standard library and third-party `http.Handler` implementations (e.g. `http.FileServer`, `http.StripPrefix(...)`) can be passed directly to route registrations alongside callable functions.

The error message and `Handler` doc comment are updated to reflect the broadened input. The existing func-typed fast paths (`func(Context)`, `func(w, r)`, `http.HandlerFunc`, `func() (int, string)`) are unchanged.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.