### PR TITLE
route: add Match for arbitrary per-route request predicates

### DIFF
--- a/internal/route/leaf.go
+++ b/internal/route/leaf.go
@@ -30,6 +30,8 @@ const (
 type Leaf interface {
 	// SetHeaderMatcher sets the HeaderMatcher for the leaf.
 	SetHeaderMatcher(m *HeaderMatcher)
+	// SetPredicateMatcher sets the PredicateMatcher for the leaf.
+	SetPredicateMatcher(m *PredicateMatcher)
 
 	// URLPath fills in bind parameters with given values to build the "path"
 	// portion of the URL. If `withOptional` is true, the path will include the
@@ -50,16 +52,17 @@ type Leaf interface {
 	getMatchStyle() MatchStyle
 	// match returns true if the leaf matches the segment, values of bind parameters
 	// are stored in the `Params`.
-	match(segment string, params Params, header http.Header) bool
+	match(segment string, params Params, req *http.Request) bool
 }
 
 // baseLeaf contains common fields for any leaf.
 type baseLeaf struct {
-	parent        Tree           // The parent tree this leaf belongs to.
-	route         *Route         // The route that the segment belongs to.
-	segment       *Segment       // The segment that the leaf is derived from.
-	handler       Handler        // The handler bound to the leaf.
-	headerMatcher *HeaderMatcher // The matcher for header values.
+	parent           Tree              // The parent tree this leaf belongs to.
+	route            *Route            // The route that the segment belongs to.
+	segment          *Segment          // The segment that the leaf is derived from.
+	handler          Handler           // The handler bound to the leaf.
+	headerMatcher    *HeaderMatcher    // The matcher for header values.
+	predicateMatcher *PredicateMatcher // The matcher for arbitrary request predicates.
 }
 
 func (l *baseLeaf) getParent() Tree {
@@ -74,8 +77,26 @@ func (l *baseLeaf) SetHeaderMatcher(m *HeaderMatcher) {
 	l.headerMatcher = m
 }
 
-func (l *baseLeaf) matchHeader(header http.Header) bool {
-	return l.headerMatcher == nil || l.headerMatcher.Match(header)
+func (l *baseLeaf) SetPredicateMatcher(m *PredicateMatcher) {
+	l.predicateMatcher = m
+}
+
+// matchDynamic returns true if both the header and predicate matchers (if
+// configured) accept the request. Routes without these matchers always match.
+func (l *baseLeaf) matchDynamic(req *http.Request) bool {
+	if l.headerMatcher != nil {
+		var h http.Header
+		if req != nil {
+			h = req.Header
+		}
+		if !l.headerMatcher.Match(h) {
+			return false
+		}
+	}
+	if l.predicateMatcher != nil && !l.predicateMatcher.Match(req) {
+		return false
+	}
+	return true
 }
 
 func (l *baseLeaf) URLPath(vals map[string]string, withOptional bool) string {
@@ -136,8 +157,8 @@ func (*staticLeaf) getMatchStyle() MatchStyle {
 	return matchStyleStatic
 }
 
-func (l *staticLeaf) match(segment string, _ Params, header http.Header) bool {
-	return l.literals == segment && l.matchHeader(header)
+func (l *staticLeaf) match(segment string, _ Params, req *http.Request) bool {
+	return l.literals == segment && l.matchDynamic(req)
 }
 
 func (l *staticLeaf) Static() bool {
@@ -162,13 +183,13 @@ func (*regexLeaf) getMatchStyle() MatchStyle {
 	return matchStyleRegex
 }
 
-func (l *regexLeaf) match(segment string, params Params, header http.Header) bool {
+func (l *regexLeaf) match(segment string, params Params, req *http.Request) bool {
 	submatches := l.regexp.FindStringSubmatch(segment)
 	if len(submatches) < len(l.binds)+1 {
 		return false
 	}
 
-	if !l.matchHeader(header) {
+	if !l.matchDynamic(req) {
 		return false
 	}
 
@@ -188,8 +209,8 @@ func (*placeholderLeaf) getMatchStyle() MatchStyle {
 	return matchStylePlaceholder
 }
 
-func (l *placeholderLeaf) match(segment string, params Params, header http.Header) bool {
-	if !l.matchHeader(header) {
+func (l *placeholderLeaf) match(segment string, params Params, req *http.Request) bool {
+	if !l.matchDynamic(req) {
 		return false
 	}
 	params[l.bind] = segment
@@ -207,8 +228,8 @@ func (*matchAllLeaf) getMatchStyle() MatchStyle {
 	return matchStyleAll
 }
 
-func (l *matchAllLeaf) match(segment string, params Params, header http.Header) bool {
-	if !l.matchHeader(header) {
+func (l *matchAllLeaf) match(segment string, params Params, req *http.Request) bool {
+	if !l.matchDynamic(req) {
 		return false
 	}
 	params[l.bind] = segment
@@ -219,14 +240,14 @@ func (l *matchAllLeaf) match(segment string, params Params, header http.Header) 
 // defined). The `path` should be original request path, `segment` should NOT be
 // unescaped by the caller. It returns true if segments are captured within the
 // limit, and the capture result is stored in `params`.
-func (l *matchAllLeaf) matchAll(path, segment string, next int, params Params, header http.Header) bool {
+func (l *matchAllLeaf) matchAll(path, segment string, next int, params Params, req *http.Request) bool {
 	// Do `next-1` because "next" starts at the next character of preceding "/".
 	// Do `strings.Count()+1` because the segment itself also counts. E.g. "webapi" +
 	// "users/events" => 3
 	if l.capture > 0 && l.capture < strings.Count(path[next-1:], "/")+1 {
 		return false
 	}
-	if !l.matchHeader(header) {
+	if !l.matchDynamic(req) {
 		return false
 	}
 

--- a/internal/route/predicate_matcher.go
+++ b/internal/route/predicate_matcher.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package route
+
+import "net/http"
+
+// Predicate is an arbitrary request matching criterion. The route is matched
+// only if the predicate returns true.
+type Predicate func(*http.Request) bool
+
+// PredicateMatcher stores a list of predicates that all must return true for
+// the match to succeed.
+type PredicateMatcher struct {
+	predicates []Predicate
+}
+
+// NewPredicateMatcher creates a new PredicateMatcher with the given predicates.
+func NewPredicateMatcher(predicates []Predicate) *PredicateMatcher {
+	return &PredicateMatcher{
+		predicates: predicates,
+	}
+}
+
+// Match returns true if all predicates return true for the given request. A
+// nil request is treated as a non-match when any predicate is configured.
+func (m *PredicateMatcher) Match(req *http.Request) bool {
+	if len(m.predicates) == 0 {
+		return true
+	}
+	if req == nil {
+		return false
+	}
+	for _, p := range m.predicates {
+		if !p(req) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/route/predicate_matcher_test.go
+++ b/internal/route/predicate_matcher_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Flamego. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPredicateMatcher(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	tests := []struct {
+		name       string
+		predicates []Predicate
+		req        *http.Request
+		want       bool
+	}{
+		{
+			name:       "no predicates",
+			predicates: nil,
+			req:        req,
+			want:       true,
+		},
+		{
+			name:       "no predicates with nil request",
+			predicates: nil,
+			req:        nil,
+			want:       true,
+		},
+		{
+			name: "all true",
+			predicates: []Predicate{
+				func(*http.Request) bool { return true },
+				func(*http.Request) bool { return true },
+			},
+			req:  req,
+			want: true,
+		},
+		{
+			name: "first false short-circuits",
+			predicates: []Predicate{
+				func(*http.Request) bool { return false },
+				func(*http.Request) bool { panic("must not be called") },
+			},
+			req:  req,
+			want: false,
+		},
+		{
+			name: "last false",
+			predicates: []Predicate{
+				func(*http.Request) bool { return true },
+				func(*http.Request) bool { return false },
+			},
+			req:  req,
+			want: false,
+		},
+		{
+			name: "nil request with predicates fails",
+			predicates: []Predicate{
+				func(*http.Request) bool { return true },
+			},
+			req:  nil,
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := NewPredicateMatcher(test.predicates).Match(test.req)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/route/tree.go
+++ b/internal/route/tree.go
@@ -16,10 +16,11 @@ import (
 
 // Tree is a tree derived from a segment.
 type Tree interface {
-	// Match matches a leaf for the given request path and provided headers, values
-	// of bind parameters are stored in the `Params`. The `Params` may contain extra
-	// values that do not belong to the final leaf due to backtrace.
-	Match(path string, header http.Header) (Leaf, Params, bool)
+	// Match matches a leaf for the given request, values of bind parameters are
+	// stored in the `Params`. The `Params` may contain extra values that do not
+	// belong to the final leaf due to backtrace. The `req` may be nil when there
+	// is no need to match against headers or predicates.
+	Match(path string, req *http.Request) (Leaf, Params, bool)
 
 	// getParent returns the parent tree. The root tree does not have parent.
 	getParent() Tree
@@ -47,7 +48,7 @@ type Tree interface {
 	match(segment string, params Params) bool
 	// matchNextSegment advances the `next` cursor for matching next segment in the
 	// request path.
-	matchNextSegment(path string, next int, params Params, header http.Header) (Leaf, bool)
+	matchNextSegment(path string, next int, params Params, req *http.Request) (Leaf, bool)
 }
 
 // baseTree contains common fields and methods for any tree.
@@ -309,7 +310,7 @@ func (t *matchAllTree) getBinds() []string {
 // sibling (static, regex, or placeholder), that match is committed immediately
 // and longer partitions are not explored — match style priority outranks
 // partition length, just as it does in `matchSubtree`.
-func (t *matchAllTree) matchAll(path, segment string, next int, params Params, header http.Header) (Leaf, bool) {
+func (t *matchAllTree) matchAll(path, segment string, next int, params Params, req *http.Request) (Leaf, bool) {
 	captured := 1 // Starts with 1 because the segment itself also count.
 
 	var (
@@ -325,7 +326,7 @@ func (t *matchAllTree) matchAll(path, segment string, next int, params Params, h
 		trial := make(Params, len(params))
 		maps.Copy(trial, params)
 
-		leaf, ok := t.matchNextSegment(path, next, trial, header)
+		leaf, ok := t.matchNextSegment(path, next, trial, req)
 		if ok {
 			if t.capture <= 0 {
 				// Lazy: commit on first match.
@@ -500,9 +501,9 @@ func AddRoute(t Tree, r *Route, h Handler) (Leaf, error) {
 
 // matchLeaf returns the matched leaf and true if any leaf of the tree matches
 // the given segment.
-func (t *baseTree) matchLeaf(segment string, params Params, header http.Header) (Leaf, bool) {
+func (t *baseTree) matchLeaf(segment string, params Params, req *http.Request) (Leaf, bool) {
 	for _, l := range t.leaves {
-		ok := l.match(segment, params, header)
+		ok := l.match(segment, params, req)
 		if ok {
 			return l, true
 		}
@@ -512,10 +513,10 @@ func (t *baseTree) matchLeaf(segment string, params Params, header http.Header) 
 
 // matchSubtree returns the matched leaf and true if any subtree or leaf of the
 // tree matches the given segment.
-func (t *baseTree) matchSubtree(path, segment string, next int, params Params, header http.Header) (Leaf, bool) {
+func (t *baseTree) matchSubtree(path, segment string, next int, params Params, req *http.Request) (Leaf, bool) {
 	for _, st := range t.subtrees {
 		if st.getMatchStyle() == matchStyleAll {
-			leaf, ok := st.(*matchAllTree).matchAll(path, segment, next, params, header)
+			leaf, ok := st.(*matchAllTree).matchAll(path, segment, next, params, req)
 			if ok {
 				return leaf, true
 			}
@@ -531,7 +532,7 @@ func (t *baseTree) matchSubtree(path, segment string, next int, params Params, h
 			continue
 		}
 
-		leaf, ok := st.matchNextSegment(path, next, params, header)
+		leaf, ok := st.matchNextSegment(path, next, params, req)
 		if !ok {
 			continue
 		}
@@ -545,7 +546,7 @@ func (t *baseTree) matchSubtree(path, segment string, next int, params Params, h
 			return nil, false
 		}
 
-		ok := leaf.(*matchAllLeaf).matchAll(path, segment, next, params, header)
+		ok := leaf.(*matchAllLeaf).matchAll(path, segment, next, params, req)
 		if ok {
 			return leaf, ok
 		}
@@ -554,18 +555,18 @@ func (t *baseTree) matchSubtree(path, segment string, next int, params Params, h
 	return nil, false
 }
 
-func (t *baseTree) matchNextSegment(path string, next int, params Params, header http.Header) (Leaf, bool) {
+func (t *baseTree) matchNextSegment(path string, next int, params Params, req *http.Request) (Leaf, bool) {
 	i := strings.Index(path[next:], "/")
 	if i == -1 {
-		return t.matchLeaf(path[next:], params, header)
+		return t.matchLeaf(path[next:], params, req)
 	}
-	return t.matchSubtree(path, path[next:next+i], next+i+1, params, header)
+	return t.matchSubtree(path, path[next:next+i], next+i+1, params, req)
 }
 
-func (t *baseTree) Match(path string, header http.Header) (Leaf, Params, bool) {
+func (t *baseTree) Match(path string, req *http.Request) (Leaf, Params, bool) {
 	path = strings.TrimLeft(path, "/")
 	params := make(Params)
-	leaf, ok := t.matchNextSegment(path, 0, params, header)
+	leaf, ok := t.matchNextSegment(path, 0, params, req)
 	if !ok {
 		return nil, nil, false
 	}

--- a/internal/route/tree_test.go
+++ b/internal/route/tree_test.go
@@ -7,6 +7,7 @@ package route
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
@@ -1164,11 +1165,11 @@ func TestTree_MatchHeader(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.path, func(t *testing.T) {
-			header := make(http.Header, len(test.header))
+			req := httptest.NewRequest(http.MethodGet, "http://example.com"+test.path, nil)
 			for k, v := range test.header {
-				header.Set(k, v)
+				req.Header.Set(k, v)
 			}
-			leaf, params, ok := tree.Match(test.path, header)
+			leaf, params, ok := tree.Match(test.path, req)
 			require.Equal(t, test.wantOK, ok)
 
 			if !ok {

--- a/router.go
+++ b/router.go
@@ -135,8 +135,9 @@ func (r *router) HandlerWrapper(f func(Handler) Handler) {
 
 // Route is a wrapper of the route leaves and its router.
 type Route struct {
-	router *router
-	leaves map[string]route.Leaf
+	router     *router
+	leaves     map[string]route.Leaf
+	predicates []route.Predicate // The list of predicates accumulated across Match calls.
 }
 
 // Headers uses given key-value pairs as the list of matching criteria for
@@ -166,6 +167,46 @@ func (r *Route) Headers(pairs ...string) *Route {
 		leaf.SetHeaderMatcher(route.NewHeaderMatcher(matches))
 
 		// Delete static route from fast paths since header matches are dynamic.
+		if leaf.Static() {
+			delete(r.router.staticRoutes[m], leaf.Route())
+		}
+	}
+	return r
+}
+
+// Match adds an arbitrary predicate as an additional matching criterion for the
+// route. The predicate is evaluated only after the request path (and any
+// Headers matchers) match. If it returns false, the request falls through to
+// the next candidate route just like a failed Headers match — it does not halt
+// the routing process.
+//
+// Multiple calls to Match accumulate and are combined with AND: every
+// predicate must return true for the route to match. When combined with
+// Headers, both must pass. The predicate does not affect the matching priority
+// of the route, nor does it participate in URLPath construction.
+//
+// For example:
+//
+//	f.Get("/admin", h).Match(func(r *http.Request) bool {
+//	    return strings.HasPrefix(r.RemoteAddr, "10.")
+//	})
+//
+//	f.Get("/", h).
+//	    Headers("Accept", "application/json").
+//	    Match(func(r *http.Request) bool { return r.TLS != nil })
+//
+// Panics if fn is nil.
+func (r *Route) Match(fn func(*http.Request) bool) *Route {
+	if fn == nil {
+		panic("nil predicate function")
+	}
+
+	r.predicates = append(r.predicates, fn)
+	matcher := route.NewPredicateMatcher(r.predicates)
+	for m, leaf := range r.leaves {
+		leaf.SetPredicateMatcher(matcher)
+
+		// Delete static route from fast paths since predicate matches are dynamic.
 		if leaf.Static() {
 			delete(r.router.staticRoutes[m], leaf.Route())
 		}
@@ -360,7 +401,7 @@ func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	leaf, params, ok := routeTree.Match(req.URL.Path, req.Header)
+	leaf, params, ok := routeTree.Match(req.URL.Path, req)
 	if !ok {
 		r.notFound(w, req)
 		return

--- a/router_test.go
+++ b/router_test.go
@@ -627,11 +627,12 @@ func BenchmarkRouter_ServeHTTP_NoMatch(b *testing.B) {
 	req, err := http.NewRequest(http.MethodGet, "/users/42", nil)
 	require.NoError(b, err)
 
-	resp := httptest.NewRecorder()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		f.ServeHTTP(resp, req)
+		// A fresh recorder per iteration so accumulated state (wroteHeader,
+		// Body, Code) does not skew alloc/timing measurements.
+		f.ServeHTTP(httptest.NewRecorder(), req)
 	}
 }
 
@@ -644,10 +645,9 @@ func BenchmarkRouter_ServeHTTP_WithMatch(b *testing.B) {
 	req, err := http.NewRequest(http.MethodGet, "/users/42", nil)
 	require.NoError(b, err)
 
-	resp := httptest.NewRecorder()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		f.ServeHTTP(resp, req)
+		f.ServeHTTP(httptest.NewRecorder(), req)
 	}
 }

--- a/router_test.go
+++ b/router_test.go
@@ -298,6 +298,179 @@ func TestRoute_Headers(t *testing.T) {
 	})
 }
 
+func TestRoute_Match(t *testing.T) {
+	t.Run("nil predicate panics", func(t *testing.T) {
+		f := New()
+		defer func() {
+			assert.Equal(t, "nil predicate function", recover())
+		}()
+		f.Get("/", func() {}).Match(nil)
+	})
+
+	t.Run("predicate true matches", func(t *testing.T) {
+		f := New()
+		f.Get("/", func() {}).Match(func(*http.Request) bool { return true })
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		f.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	t.Run("predicate false falls through to lower-priority sibling leaf", func(t *testing.T) {
+		// A regex leaf has higher matching priority than a placeholder leaf at
+		// the same tree node. With a failing predicate on the regex leaf, the
+		// tree must continue to the placeholder leaf rather than halt.
+		f := New()
+		called := ""
+		f.Get("/{id: /[0-9]+/}", func(c Context) {
+			called = "regex:" + c.Param("id")
+		}).Match(func(r *http.Request) bool {
+			return r.Header.Get("X-Special") == "yes"
+		})
+		f.Get("/{name}", func(c Context) {
+			called = "placeholder:" + c.Param("name")
+		})
+
+		t.Run("predicate true picks regex leaf", func(t *testing.T) {
+			called = ""
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/42", nil)
+			require.NoError(t, err)
+			req.Header.Set("X-Special", "yes")
+			f.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "regex:42", called)
+		})
+
+		t.Run("predicate false falls through to placeholder", func(t *testing.T) {
+			called = ""
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/42", nil)
+			require.NoError(t, err)
+			f.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "placeholder:42", called)
+		})
+	})
+
+	t.Run("predicate false on only candidate yields not found", func(t *testing.T) {
+		f := New()
+		f.Get("/", func() {}).Match(func(*http.Request) bool { return false })
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
+
+	t.Run("multiple predicates AND together", func(t *testing.T) {
+		f := New()
+		f.Get("/", func() {}).
+			Match(func(r *http.Request) bool { return r.Header.Get("A") == "1" }).
+			Match(func(r *http.Request) bool { return r.Header.Get("B") == "2" })
+
+		t.Run("both true", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("A", "1")
+			req.Header.Set("B", "2")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusOK, resp.Code)
+		})
+
+		t.Run("first false", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("B", "2")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
+		})
+
+		t.Run("second false", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("A", "1")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
+		})
+	})
+
+	t.Run("combined with Headers both must pass", func(t *testing.T) {
+		f := New()
+		f.Get("/", func() {}).
+			Headers("Server", "Caddy").
+			Match(func(r *http.Request) bool { return r.Header.Get("Trace") == "on" })
+
+		t.Run("both pass", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("Server", "Caddy")
+			req.Header.Set("Trace", "on")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusOK, resp.Code)
+		})
+
+		t.Run("header fails", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("Trace", "on")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
+		})
+
+		t.Run("predicate fails", func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+			req.Header.Set("Server", "Caddy")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusNotFound, resp.Code)
+		})
+	})
+
+	t.Run("predicate false on static route falls back to other route", func(t *testing.T) {
+		// Verifies the static fast path is bypassed when a predicate is attached.
+		f := New()
+		called := ""
+		f.Get("/admin", func() { called = "admin-internal" }).
+			Match(func(r *http.Request) bool { return r.Header.Get("X-Internal") == "1" })
+		f.Get("/{name}", func(c Context) { called = "fallback:" + c.Param("name") })
+
+		t.Run("predicate true takes static-shaped route", func(t *testing.T) {
+			called = ""
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/admin", nil)
+			require.NoError(t, err)
+			req.Header.Set("X-Internal", "1")
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "admin-internal", called)
+		})
+
+		t.Run("predicate false falls through to placeholder", func(t *testing.T) {
+			called = ""
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/admin", nil)
+			require.NoError(t, err)
+			f.ServeHTTP(resp, req)
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "fallback:admin", called)
+		})
+	})
+}
+
 func TestRoute_Name(t *testing.T) {
 	contextCreator := func(w http.ResponseWriter, r *http.Request, params route.Params, handlers []Handler, urlPath urlPather) internalContext {
 		return newMockContext()
@@ -441,5 +614,40 @@ func TestComboRoute(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Code)
 			assert.Equal(t, "/", gotRoute)
 		})
+	}
+}
+
+// BenchmarkRouter_ServeHTTP_NoMatch exercises a placeholder route that does
+// not have any Match predicate attached, to detect regressions on the common
+// path from threading *http.Request through tree matching.
+func BenchmarkRouter_ServeHTTP_NoMatch(b *testing.B) {
+	f := New()
+	f.Get("/users/{id}", func() {})
+
+	req, err := http.NewRequest(http.MethodGet, "/users/42", nil)
+	require.NoError(b, err)
+
+	resp := httptest.NewRecorder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.ServeHTTP(resp, req)
+	}
+}
+
+// BenchmarkRouter_ServeHTTP_WithMatch exercises a placeholder route guarded
+// by a Match predicate, as a comparison point for the no-Match baseline.
+func BenchmarkRouter_ServeHTTP_WithMatch(b *testing.B) {
+	f := New()
+	f.Get("/users/{id}", func() {}).Match(func(*http.Request) bool { return true })
+
+	req, err := http.NewRequest(http.MethodGet, "/users/42", nil)
+	require.NoError(b, err)
+
+	resp := httptest.NewRecorder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.ServeHTTP(resp, req)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `Route.Match(fn func(*http.Request) bool) *Route`, a chainable matcher that lets users attach an arbitrary predicate as an additional route matching criterion. Closes the gap with Rails `constraints: ->(req){...}` and Symfony condition expressions.

```go
f.Get("/admin", h).Match(func(r *http.Request) bool {
    return strings.HasPrefix(r.RemoteAddr, "10.")
})

f.Get("/", h).
    Headers("Accept", "application/json").
    Match(func(r *http.Request) bool { return r.TLS != nil })

f.Get("/x", h).Match(predA).Match(predB) // AND
```

### Semantics

- Evaluated after the path matches.
- A `false` predicate falls through to the next candidate leaf (same as `Headers()`), it does not halt routing.
- Multiple `Match` calls AND together.
- Combined with `Headers()`: both must pass.
- A nil function panics at registration.
- Does not affect matching priority or `URLPath` construction.
- Attaching a predicate to a static-shaped route removes it from the static fast-path so the predicate is honored on every request.

### Implementation notes

- New `route.Predicate` and `route.PredicateMatcher` types live alongside `HeaderMatcher` in `internal/route`.
- `Tree.Match` now takes `*http.Request` instead of `http.Header` so leaf matchers can see the full request. The header path is unchanged in behavior.
- Leaf-level `matchDynamic(req)` AND-combines header and predicate matchers.

### Benchmark

No regression on the no-`Match` path (placeholder route, `GET /users/{id}` → `/users/42`):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| baseline | ~575 | 1040 | 12 |
| this PR  | ~586 | 1040 | 12 |

Difference is within run-to-run noise; allocation profile is identical.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `TestRoute_Match` covers: nil-fn panic, true/false predicate, fall-through to lower-priority sibling leaf, fall-through from static-shaped predicate route to placeholder fallback, multiple-predicate AND, and combined `Headers()` + `Match()`.
- [x] `TestPredicateMatcher` covers AND short-circuit and nil-request behavior.
- [x] Existing `TestRoute_Headers` and tree-matching tests still pass.

Docs PRs for [flamego.dev](https://github.com/flamego/flamego.dev) (EN) and [flamego.cn](https://github.com/flamego/flamego.cn) (ZH) to follow once a release version is known.