### PR TITLE
docs: generate llms.txt for the English site

### DIFF
--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -15,6 +15,11 @@ languages:
     weight: 1
     title: Flamego
     contentDir: content
+    outputs:
+      home:
+        - html
+        - rss
+        - llms
     params:
       editURL:
         base: https://github.com/flamego/flamego/edit/main/docs/content
@@ -82,6 +87,13 @@ languages:
 module:
   imports:
     - path: github.com/imfing/hextra
+
+outputFormats:
+  llms:
+    mediaType: text/plain
+    baseName: llms
+    isPlainText: true
+    notAlternative: true
 
 markup:
   goldmark:

--- a/docs/layouts/home.llms.txt
+++ b/docs/layouts/home.llms.txt
@@ -1,0 +1,31 @@
+{{- define "page-summary" -}}
+{{- with .Description -}}
+: {{ . }}
+{{- else -}}
+{{- $html := printf "%s" .Summary -}}
+{{- $stripped := $html | replaceRE "(?s)<pre.*?</pre>" "" | replaceRE "(?s)<code.*?</code>" "" | replaceRE "(?s)<div[^>]*>" "" | replaceRE "(?s)</div>" "" -}}
+{{- $text := $stripped | plainify | htmlUnescape | replaceRE "\\s+" " " | strings.TrimSpace -}}
+{{- with $text -}}: {{ . | truncate 200 }}{{- end -}}
+{{- end -}}
+{{- end -}}
+# {{ site.Title }}
+
+> {{ site.Params.description }}
+
+{{- $sections := slice "starter-guide" "core-concepts" "routing" "middleware" "faqs" }}
+{{- range $sections }}
+{{- $page := site.GetPage . }}
+{{- if $page }}
+
+## {{ $page.Title | default (humanize .) }}
+
+{{- $children := where site.RegularPages "Section" . }}
+{{- if $children }}
+{{- range $children.ByWeight }}
+- [{{ .Title }}]({{ .Permalink }}){{ template "page-summary" . }}
+{{- end }}
+{{- else }}
+- [{{ $page.Title | default (humanize .) }}]({{ $page.Permalink }}){{ template "page-summary" $page }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Add an `llms` Hugo output format (plain text, baseName `llms`) and enable it on the English language home output only.
- Add `layouts/home.llms.txt` to render the [llms.txt](https://llmstxt.org) directory: site title, summary, and grouped sections (Starter guide, Core concepts, Routing, Middleware, FAQs).

After deploy the file will be served at https://flamego.dev/llms.txt.

## Test plan
- [x] `hugo` builds without error and writes `public/llms.txt`
- [x] `public/zh/llms.txt` is not generated (English only)
- [x] Output contains H1 title, blockquote description, and one bullet per page with a short summary