### PR TITLE
docs: fix iOS page dimming and tighten footer

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -9,6 +9,21 @@ code, pre, kbd, samp, .chroma, .hextra-code-block {
   font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+/* iOS: stop code blocks from dimming the whole page.
+   Hextra applies `filter: contrast(150%)` to every <pre>. A CSS filter promotes
+   the element to its own compositing layer rendered in extended color space; on
+   iOS (EDR-capable displays) contrast(150%) pushes the bright code-block pixels
+   above the SDR white point into HDR headroom, so iOS allocates EDR brightness
+   for it and tone-maps the rest of the SDR page DOWN — making everything except
+   the code block look dimmed. Desktop has little/no EDR headroom so it looks
+   fine, and dark mode never pushes past white. Dropping the filter removes the
+   HDR trigger. The 150% contrast bump is cosmetic and unnecessary with our
+   explicit syntax palette below. */
+.content pre,
+.hextra-code-block pre {
+  filter: none !important;
+}
+
 .hextra-nav-container nav > a > span {
   font-family: 'Quicksand', system-ui, -apple-system, sans-serif;
   font-weight: 500;

--- a/docs/layouts/_partials/footer.html
+++ b/docs/layouts/_partials/footer.html
@@ -23,11 +23,11 @@
   </div>
   {{- if $copyrightSectionVisible -}}
     <div
-      class="hextra-max-footer-width hx:mx-auto hx:flex hx:justify-center hx:py-12 hx:pl-[max(env(safe-area-inset-left),1.5rem)] hx:pr-[max(env(safe-area-inset-right),1.5rem)] hx:text-gray-600 hx:dark:text-gray-400 hx:md:justify-start"
+      class="hextra-max-footer-width hx:mx-auto hx:flex hx:justify-center hx:py-4 hx:pl-[max(env(safe-area-inset-left),1.5rem)] hx:pr-[max(env(safe-area-inset-right),1.5rem)] hx:text-gray-600 hx:dark:text-gray-400 hx:md:justify-start"
     >
       <div class="hx:flex hx:w-full hx:flex-col hx:items-center hx:sm:items-start">
         {{- if (.Site.Params.footer.displayPoweredBy | default true) }}<div class="hx:font-semibold">{{ template "theme-credit" $poweredBy }}</div>{{- end -}}
-        {{- if .Site.Params.footer.displayCopyright }}<div class="hx:mt-6 hx:text-xs">{{ $copyright | markdownify }}</div>{{- end -}}
+        {{- if .Site.Params.footer.displayCopyright }}<div class="hx:text-sm">{{ $copyright | markdownify }}</div>{{- end -}}
       </div>
     </div>
   {{- end -}}


### PR DESCRIPTION
## Problem

On iOS (Safari and Chrome), the docs site in **light mode** rendered with everything dimmed/washed-out **except the code blocks**. Desktop looked fine, and dark mode looked fine. It happened on every page.

## Root cause

Hextra applies `filter: contrast(150%)` to every code-block `<pre>`. A CSS `filter` promotes the element to its own compositing layer rendered in extended color space. On iOS (EDR-capable displays), `contrast(150%)` pushes the bright code-block pixels **above the SDR white point into the display's EDR/HDR headroom**. iOS then allocates real HDR brightness for the code block and **tone-maps the rest of the SDR page downward** — so everything except the code block looked dimmed.

- **Desktop** is unaffected: laptop displays have little/no EDR headroom, so `contrast(150%)` just clamps at white.
- **Dark mode** is unaffected: dark code content doesn't push pixels past the white point.
- **Every page** was affected because every doc page has a code block.

## Fix

- Drop the filter on code blocks (`filter: none !important` on `.content pre, .hextra-code-block pre`). The 150% contrast bump was cosmetic and is redundant with the explicit syntax palette already defined in `custom.css`.

Also included (the second half of the original report):

- Footer copyright row: reduce vertical padding (`py-12` → `py-4`), bump copyright text (`text-xs` → `text-sm`), drop the now-unneeded top margin. (Note: `py-6`/`py-8` are **not** compiled by this Tailwind build, so only `py-1/2/3/4/12` produce real padding — `py-4` chosen deliberately.)

## Testing

- Verified the compiled CSS: `.content pre,.hextra-code-block pre{filter:none!important}` lands after the theme's `contrast(150%)` rule, so it wins the cascade.
- Verified `py-4` generates real `padding-block` in the compiled output.
- Confirmed on-device on iOS that the dimming is gone.