### PR TITLE
feat: support plaintext panic recovery

### DIFF
--- a/docs/content.zh/core-services.md
+++ b/docs/content.zh/core-services.md
@@ -362,6 +362,17 @@ func main() {
 
 ![panic recovery](/imgs/panic-recovery.png)
 
+如果要在开发模式下以纯文本格式返回 panic 和堆栈跟踪，可传入
+[`flamego.RecoveryOptions`](https://pkg.go.dev/github.com/flamego/flamego#RecoveryOptions)：
+
+```go
+f.Use(flamego.Recovery(
+	flamego.RecoveryOptions{
+		PlainText: true,
+	},
+))
+```
+
 ## 响应静态资源
 
 {{< callout type="info" >}}

--- a/docs/content/core-services.md
+++ b/docs/content/core-services.md
@@ -366,6 +366,17 @@ When you run the above program and visit [http://localhost:2830/](http://localho
 
 ![panic recovery](/imgs/panic-recovery.png)
 
+To return the panic and stack trace as plain text in development mode, pass
+[`flamego.RecoveryOptions`](https://pkg.go.dev/github.com/flamego/flamego#RecoveryOptions):
+
+```go
+f.Use(flamego.Recovery(
+	flamego.RecoveryOptions{
+		PlainText: true,
+	},
+))
+```
+
 ## Serving static files
 
 {{< callout type="info" >}}

--- a/recovery.go
+++ b/recovery.go
@@ -138,7 +138,7 @@ pre {
 	return LoggerInvoker(func(c Context, logger *log.Logger) {
 		defer func() {
 			if err := recover(); err != nil {
-				stack := stack(3)
+				stack := bytes.TrimRight(stack(3), "\n")
 				logger.Error(fmt.Sprintf("PANIC: %s\n%s", err, stack))
 
 				// Lookup the current ResponseWriter
@@ -150,7 +150,7 @@ pre {
 				if Env() == EnvTypeDev {
 					if opt.PlainText {
 						w.Header().Set("Content-Type", "text/plain")
-						body = []byte(fmt.Sprintf("PANIC: %s\n%s", err, bytes.TrimRight(stack, "\n")))
+						body = []byte(fmt.Sprintf("PANIC: %s\n%s", err, stack))
 					} else {
 						w.Header().Set("Content-Type", "text/html")
 						body = []byte(fmt.Sprintf(html, err, stack))

--- a/recovery.go
+++ b/recovery.go
@@ -16,10 +16,23 @@ import (
 	"github.com/flamego/flamego/inject"
 )
 
+// RecoveryOptions contains options for the flamego.Recovery middleware.
+type RecoveryOptions struct {
+	// PlainText indicates whether to respond with plain text instead of HTML when
+	// recovering from a panic in development mode.
+	PlainText bool
+}
+
 // Recovery returns a middleware handler that recovers from any panics and
 // writes a 500 status code to the response if there was one. While in
-// development mode (EnvTypeDev), Recovery will also output the panic as HTML.
-func Recovery() Handler {
+// development mode (EnvTypeDev), Recovery will also output the panic as HTML,
+// or as plain text when the PlainText option is enabled.
+func Recovery(opts ...RecoveryOptions) Handler {
+	var opt RecoveryOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
 	const html = `<html>
 <head><title>PANIC: %[1]s</title>
 <meta charset="utf-8" />
@@ -135,8 +148,13 @@ pre {
 				// Respond with panic message only in development mode
 				var body []byte
 				if Env() == EnvTypeDev {
-					w.Header().Set("Content-Type", "text/html")
-					body = []byte(fmt.Sprintf(html, err, stack))
+					if opt.PlainText {
+						w.Header().Set("Content-Type", "text/plain")
+						body = []byte(fmt.Sprintf("PANIC: %s\n%s", err, bytes.TrimRight(stack, "\n")))
+					} else {
+						w.Header().Set("Content-Type", "text/html")
+						body = []byte(fmt.Sprintf(html, err, stack))
+					}
 				} else {
 					w.Header().Set("Content-Type", "text/plain")
 					body = []byte(http.StatusText(http.StatusInternalServerError))

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -31,6 +31,25 @@ func TestRecovery(t *testing.T) {
 		assert.Contains(t, resp.Body.String(), "PANIC")
 	})
 
+	t.Run("recovery from panic in plain text", func(t *testing.T) {
+		f := NewWithLogger(&bytes.Buffer{})
+		f.Use(Recovery(RecoveryOptions{PlainText: true}))
+		f.Use(func() { panic("here is a panic!") })
+		f.Get("/", func() {})
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		assert.Nil(t, err)
+
+		f.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, "text/plain", resp.Header().Get("Content-Type"))
+		assert.Contains(t, resp.Body.String(), "PANIC: here is a panic!\n")
+		assert.Contains(t, resp.Body.String(), "recovery_test.go")
+		assert.NotEqual(t, '\n', resp.Body.String()[resp.Body.Len()-1])
+	})
+
 	t.Run("recovery from panic in non-development mode", func(t *testing.T) {
 		SetEnv(EnvTypeProd)
 		defer SetEnv(EnvTypeDev)


### PR DESCRIPTION
### Describe the pull request

Adds `RecoveryOptions` and lets callers request plaintext panic responses with `Recovery(RecoveryOptions{PlainText: true})`.

This adopts the behavior from Gogs's recovery middleware as first-class Flamego support: development responses contain the panic and stack trace as plaintext, while non-development responses remain redacted. Existing `Recovery()` callers retain the current HTML development response.

Documentation and a focused test for the plaintext response are included.

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/flamego/flamego/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.

### Verification

- `go test -race ./...`
- `golangci-lint run --timeout=30m`